### PR TITLE
Move demo GIF to the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # UnvibeCode
 
+![UnvibeCode AI codebase analysis demo showing connected code, business workflows, and risk findings](docs/assets/unvibecode-codebase-analysis-demo.gif)
+
 **Unvibe complex code. Trace business workflows.**
 
 Complex code hides connections, workflows, and business risks. **Unvibe it.**
@@ -10,8 +12,6 @@ Complex code hides connections, workflows, and business risks. **Unvibe it.**
 [![License](https://img.shields.io/github/license/FinanceFlash/unvibecode.svg)](LICENSE)
 
 **PyPI project:** [pypi.org/project/unvibecode](https://pypi.org/project/unvibecode/)
-
-![UnvibeCode AI codebase analysis demo showing connected code, business workflows, and risk findings](docs/assets/unvibecode-codebase-analysis-demo.gif)
 
 Explore connected code in an interactive graph, give LLMs the right context, trace business workflows, and identify critical business risks.
 


### PR DESCRIPTION
## Change

Moves the animated UnvibeCode demo directly below the `# UnvibeCode` heading so it is the first visual users see inside the README.

No other README content is changed.

## Validation

- The GIF path remains `docs/assets/unvibecode-codebase-analysis-demo.gif`.
- All 564 repository-quality tests pass locally.

This PR is intentionally limited to the GIF placement.