### PR TITLE
Align workflow-pack terminology for first-time contributors

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -68,7 +68,7 @@ The review is not required for wording-only documentation changes. Do not attach
 
 ## Contributing a pre-built workflow pack
 
-Add the workflow as one clearly named folder under `prebuilt-workflow-paths/`. Copy an existing complete pack as the structural starting point and replace its content; do not leave copied actors, states, risks, or examples from the source pack.
+Add the workflow as one clearly named folder under `prebuilt-workflow-paths/`. Copy an existing complete pack as the structural starting point and replace its content; do not leave copied people, systems, things, stages, risks, or examples from the source pack.
 
 Every pack must contain:
 
@@ -86,6 +86,15 @@ Every pack must contain:
 - `IMPLEMENT_WORKFLOW_SKILL.md`
 - `TEST_WORKFLOW_SKILL.md`
 
+Use the same terms that appear inside every workflow pack:
+
+| Workflow-pack heading | What it covers |
+| --- | --- |
+| `People and systems` | The people, teams, services, providers, and other systems involved |
+| `Things created or changed` | The important records, requests, payments, orders, messages, or other items affected |
+| `Stages` | The meaningful points that those things move through during the workflow |
+| `Must not happen` | The harmful or incorrect result that each scenario must prevent |
+
 ### MECE rules for workflow packs
 
 MECE means the pack's scenarios should be mutually exclusive enough to avoid duplicates and collectively broad enough to cover the important business paths within its stated boundary.
@@ -93,10 +102,10 @@ MECE means the pack's scenarios should be mutually exclusive enough to avoid dup
 1. **Define one business boundary.** State the exact event that starts the workflow and the authoritative outcomes that end it.
 2. **Declare included and excluded scope.** Excluded adjacent workflows must be named explicitly. Reference their packs instead of duplicating them.
 3. **Own one primary business outcome.** A pack may coordinate related effects, but it must not combine separate lifecycles such as payment, fulfilment, refund, and dispute into one oversized workflow.
-4. **Keep scenarios distinct.** Each core scenario needs a different trigger, state, permission boundary, timing condition, or failure mechanism. Rewording the same failure is not a new scenario.
-5. **Cover the whole boundary.** The 20 scenarios together must include normal completion, invalid input, denied action, state boundaries, concurrency, permission or abuse, dependency failure, partial completion, retry, and recovery where applicable.
-6. **State the forbidden outcome.** Every core scenario must say what must not happen, such as a duplicate charge, stale state transition, cross-tenant access, silent data loss, or contradictory customer outcome.
-7. **Use one vocabulary everywhere.** Actors, business objects, states, start and end events, and outcome names must match across all guides, scenarios, and skills.
+4. **Keep scenarios distinct.** Each core scenario needs a different trigger, stage, permission boundary, timing condition, or failure mechanism. Rewording the same failure is not a new scenario.
+5. **Cover the whole boundary.** The 20 scenarios together must include normal completion, invalid input, denied action, stage boundaries, concurrency, permission or abuse, dependency failure, partial completion, retry, and recovery where applicable.
+6. **Say what must not happen.** Every core scenario must name the harmful or incorrect result to prevent, such as a duplicate charge, stale stage change, cross-tenant access, silent data loss, or contradictory customer outcome.
+7. **Use one vocabulary everywhere.** `People and systems`, `Things created or changed`, `Stages`, start and end events, and outcome names must match across all guides, scenarios, and skills.
 8. **Separate generic rules from code evidence.** A reusable pack may describe expected controls. It must not claim that a repository implements a control unless file, symbol, path, or runtime evidence supports that claim.
 9. **Keep the five LLM skills task-specific.** Product specification, business-risk review, code understanding, implementation, and testing must have distinct instructions and outputs.
 10. **Make the pack self-contained.** A reader must understand a scenario without decoding internal IDs or opening several files to learn its trigger and expected result.
@@ -106,10 +115,10 @@ Before submitting, compare every proposed scenario with the other 19. Merge dupl
 ### Workflow-pack pull request checklist
 
 - [ ] The folder name is descriptive and has no numeric prefix.
-- [ ] `README.md` states start, end, included scope, and excluded scope.
+- [ ] `README.md` gives the start, end, included scope, and excluded scope.
 - [ ] The pack does not duplicate the primary outcome of an existing pack.
 - [ ] Exactly 20 distinct core scenarios are present.
-- [ ] Every core scenario includes a forbidden outcome.
+- [ ] Every core scenario says what `Must not happen`.
 - [ ] Testing scenarios cover happy, negative, boundary, concurrency, permission, partial-failure, retry, and recovery paths where applicable.
 - [ ] All 13 required files are present and use consistent terminology.
 - [ ] All five LLM skill files include valid `name` and `description` frontmatter.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@ Complete these items only when adding or changing a pre-built workflow pack.
 - [ ] The pack owns one primary business outcome and does not duplicate an existing pack.
 - [ ] The 20 core scenarios are distinct and collectively cover the declared boundary.
 - [ ] Every core scenario states what must not happen.
-- [ ] All 13 required files use consistent actors, objects, states, and outcome names.
+- [ ] All 13 required files use consistent `People and systems`, `Things created or changed`, `Stages`, and outcome names.
 
 ## Remaining limitations
 

--- a/prebuilt-workflow-paths/README.md
+++ b/prebuilt-workflow-paths/README.md
@@ -70,7 +70,7 @@ No installation, generator, schema, or build step is required. Every workflow is
 | [Right-to-erasure and Account-data Deletion](account-data-deletion-and-right-to-erasure/) | verifies and executes deletion or anonymization requests across data stores and processors |
 | [Scheduled Job Execution, Checkpoint, Retry, and Recovery](scheduled-job-execution-retry-and-recovery/) | runs scheduled work with leases, bounded input windows, checkpoints, retries, and repair |
 
-The navigation categories are only for discovery. Each workflow has its own clear start, end, state, effects, permissions, and recovery boundary.
+The navigation categories are only for discovery. Each workflow has its own clear start, end, stages, effects, permissions, and recovery boundary.
 
 ## What each workflow contains
 
@@ -79,9 +79,9 @@ Every workflow folder uses the same flat structure:
 | File | Best for | Purpose |
 |---|---|---|
 | `README.md` | Everyone | Workflow boundary, included scope, excluded scope, and file navigation |
-| `PRODUCT_AND_BUSINESS_GUIDE.md` | PMs and founders | Actors, business objects, states, decisions, paths, edge cases, acceptance criteria, and consequences |
+| `PRODUCT_AND_BUSINESS_GUIDE.md` | PMs and founders | People and systems, things created or changed, stages, decisions, paths, edge cases, acceptance criteria, and consequences |
 | `ENGINEERING_GUIDE.md` | Developers and engineering managers | Code-tracing sequence, implementation safeguards, effects, state, and recovery concerns |
-| `CORE_20_SCENARIOS.md` | Everyone | Compact checklist of the 20 essential scenarios and forbidden outcomes |
+| `CORE_20_SCENARIOS.md` | Everyone | Compact checklist of the 20 essential scenarios and what must not happen |
 | `TESTING_GUIDE.md` | QA and developers | All 20 scenarios written with Given, When, Expect, Must not happen, and suggested test levels |
 | `PATHS_AND_EDGE_CASES.md` | PMs, QA, and developers | Supported, denied, timing, boundary, concurrency, and unusual paths |
 | `PERMISSION_AND_ABUSE_GUIDE.md` | Security, PMs, and engineers | Authorization boundaries, misuse paths, tenant isolation, and protected data |
@@ -91,6 +91,8 @@ Every workflow folder uses the same flat structure:
 | `UNDERSTAND_CODE_SKILL.md` | Developers using an LLM | Traces the workflow through an existing codebase with file and symbol evidence |
 | `IMPLEMENT_WORKFLOW_SKILL.md` | Developers using an LLM | Implements or modifies the workflow while preserving its key safeguards |
 | `TEST_WORKFLOW_SKILL.md` | Testers and developers using an LLM | Designs or reviews the complete workflow-specific test set |
+
+Every `PRODUCT_AND_BUSINESS_GUIDE.md` uses the exact headings `People and systems`, `Things created or changed`, and `Stages`. Every core scenario uses `Must not happen` for the outcome that the workflow must prevent.
 
 ## Recommended reading paths
 


### PR DESCRIPTION
## What changed

- Replace `actors`, `business objects`, `states`, and `forbidden outcomes` in contributor-facing workflow instructions with the exact headings used by all workflow packs: `People and systems`, `Things created or changed`, `Stages`, and `Must not happen`.
- Add a short terminology table to the contribution guide.
- Update the workflow collection description and pull-request checklist to use the same wording.

## Why

First-time contributors were asked to follow terms that do not appear as headings inside the workflow files. This change makes the collection README, contribution guide, PR checklist, and all 18 workflow packs use one vocabulary.

## Validation

- Black passed
- Flake8 passed
- Pytest: 564 passed
- `git diff --check` passed

This PR is intentionally limited to the three contributor-guidance files.