### PR TITLE
[Challenge 2026][Improvement]: link README install section to TROUBLESHOOTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ pip install unvibecode
 python -m unvibecode review --repository "/path/to/repository"
 ```
 
+
+Running into an error? Check [Troubleshooting](docs/TROUBLESHOOTING.md) — it covers
+missing-module errors, `python` vs `python3`, and repository path issues.
+
+
 Windows example:
 
 ```powershell


### PR DESCRIPTION
## Problem and scope

The README's install/review section has no pointer to docs/TROUBLESHOOTING.md, even though that doc already has clear, correct guidance for common install issues (wrong Python environment, python vs python3, path-not-found). A user hitting an error at that first step has no signpost to the doc that would help them.

## What changed

Documentation-only change to README.md. Added a one-line pointer to docs/TROUBLESHOOTING.md directly under the main install/review command block, before the Windows example. No code paths affected.

## Verification

List the commands, fixtures, public repositories, and outputs used to verify the change.

- [ ] `python -m black --config .github/quality/pyproject.toml --check .github/quality/tests`
- [ ] `python -m flake8 --config .github/quality/.flake8 .github/quality/tests`
- [ ] `python -m pytest -c .github/quality/pyproject.toml .github/quality/tests`
- [ ] I used UnvibeCode on a representative repository when the change affects code analysis, CLI behaviour, engineering guidance, or code-specific claims.
- [x] I updated documentation for changed user-facing behaviour.
- [x] I included no credentials, proprietary source, customer data, generated customer reports, or unsanitized logs.

Not applicable: this is a wording/link-only documentation change with no code or CLI behaviour affected, so the black/flake8/pytest checks and the UnvibeCode review step don't apply, consistent with CONTRIBUTING.md's note that review is not required for wording-only documentation changes.

## Workflow-pack checks

Complete these items only when adding or changing a pre-built workflow pack.

- [ ] The start, end, included scope, and excluded scope are explicit.
- [ ] The pack owns one primary business outcome and does not duplicate an existing pack.
- [ ] The 20 core scenarios are distinct and collectively cover the declared boundary.
- [ ] Every core scenario states what must not happen.
- [ ] All 13 required files use consistent `People and systems`, `Things created or changed`, `Stages`, and outcome names.

Not applicable — this PR does not add or change a workflow pack.

## Remaining limitations

Only links from the primary install section; doesn't add links elsewhere in the README (e.g. the Documentation list) where a user troubleshooting an issue might also look.