### PR TITLE
Add engineering pre-build question series

### DIFF
--- a/AI Engineering Cheet series/smart_questions_before_you_build/00-requirements.md
+++ b/AI Engineering Cheet series/smart_questions_before_you_build/00-requirements.md
@@ -1,0 +1,42 @@
+# 00 — Requirements: Build the Right Thing
+
+> A perfectly engineered solution to the wrong problem is still a failure.
+
+```mermaid
+flowchart LR
+    A["User pain"] --> B["Outcome"]
+    B --> C["Scope"]
+    C --> D["Risky assumptions"]
+    D --> E["Acceptance evidence"]
+```
+
+## Stop and answer
+
+- [ ] Whose problem are we solving, and what are they unable to do today?
+- [ ] What observable change will prove this feature helped them?
+- [ ] Is this an experiment, prototype, internal tool, maintained feature, or production-critical system?
+- [ ] What must be included now for the outcome to be useful?
+- [ ] What is explicitly excluded from this iteration?
+- [ ] Which users, platforms, regions, volumes, and accessibility needs are in scope?
+- [ ] Which existing contracts, workflows, integrations, and behaviours cannot break?
+- [ ] What constraints are fixed: time, budget, latency, technology, privacy, or compliance?
+- [ ] Which assumption could make the whole design invalid?
+- [ ] What is the cheapest credible test of that assumption before we write most of the code?
+
+## Warning signs
+
+- The requirement describes screens or endpoints but not a user outcome.
+- “Everyone” is the target user and “better” is the success metric.
+- Stakeholders agree on the feature name but imagine different behaviour.
+
+## Evidence before code
+
+- One-paragraph problem statement
+- Measurable success and acceptance criteria
+- Must-haves and explicit non-goals
+- Constraints and unresolved assumptions
+- Named decision-maker who can accept the result
+
+## Ask an LLM or reviewer
+
+> “Separate facts from assumptions in these requirements. Find ambiguity, missing users, hidden constraints, contradictory acceptance criteria, and the smallest experiments that could prove us wrong.”

--- a/AI Engineering Cheet series/smart_questions_before_you_build/01-backend.md
+++ b/AI Engineering Cheet series/smart_questions_before_you_build/01-backend.md
@@ -1,0 +1,43 @@
+# 01 — Backend: Protect the Business Rules
+
+> The backend is not just a set of endpoints. It is where trusted decisions and business invariants live.
+
+```mermaid
+flowchart TD
+    A["Request or job"] --> B["Validate + authorise"]
+    B --> C["Apply business rules"]
+    C --> D["Commit state + effects"]
+    D --> E["Respond or publish"]
+    D -. failure .-> F["Retry, reverse, or escalate"]
+```
+
+## Stop and answer
+
+- [ ] Which service or module owns this capability and its business invariants?
+- [ ] What are the stable request, response, error, pagination, and job-status contracts?
+- [ ] Where are authentication, authorisation, payload limits, and business validation enforced?
+- [ ] Which calls may be repeated, and how will idempotency prevent duplicate effects?
+- [ ] What are the timeout, retry, backoff, cancellation, and circuit-breaker rules for each dependency?
+- [ ] What happens during concurrent updates, stale writes, reordered requests, or partial completion?
+- [ ] Which operations must be synchronous, and which should become background work?
+- [ ] How can failed work be inspected, retried, replayed, compensated, cancelled, or rejected?
+- [ ] What happens if required configuration is missing, malformed, or changed during deployment?
+- [ ] How can clients and connectors upgrade without breaking current consumers?
+
+## Warning signs
+
+- Authorisation exists only in the UI or gateway.
+- Retrying the same request can charge, create, or notify twice.
+- A dependency failure returns a generic 500 while leaving unknown state behind.
+
+## Evidence before code
+
+- Interface and error schemas
+- Business-rule ownership
+- Idempotency and concurrency strategy
+- Dependency-failure matrix
+- One documented end-to-end integration example
+
+## Ask an LLM or reviewer
+
+> “Attack this backend design with duplicate requests, stale data, concurrency, timeouts, partial failure, missing configuration, rate limits, and dependency changes. Show where business state could become invalid.”

--- a/AI Engineering Cheet series/smart_questions_before_you_build/02-frontend.md
+++ b/AI Engineering Cheet series/smart_questions_before_you_build/02-frontend.md
@@ -1,0 +1,45 @@
+# 02 — Frontend: Design Every State, Not Just Success
+
+> Users experience the states your mock-up forgot: slow, empty, stale, denied, interrupted, and failed.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Ready
+    Ready --> Loading
+    Loading --> Success
+    Loading --> Empty
+    Loading --> Error
+    Error --> Loading: Retry
+    Success --> Ready: Next action
+```
+
+## Stop and answer
+
+- [ ] What is the shortest path from arrival to the intended user outcome?
+- [ ] Which state belongs on the server, in the URL, in shared client state, in a form, or inside one component?
+- [ ] What does the user see during loading, empty, partial, successful, invalid, denied, and failed states?
+- [ ] How are double-clicks, repeated submissions, stale responses, navigation, and interrupted requests handled?
+- [ ] Can the user understand and recover from an error without seeing technical language?
+- [ ] Can every important action be completed by keyboard and understood by a screen reader?
+- [ ] Does the flow work at high zoom, reduced motion, low vision, narrow screens, and low bandwidth?
+- [ ] How will large lists, slow devices, old supported browsers, and weak networks affect the experience?
+- [ ] Which server/client contract changes could silently break rendering or expose unsafe content?
+- [ ] Are destructive, costly, privacy-sensitive, and irreversible actions explained and protected appropriately?
+
+## Warning signs
+
+- The design contains only the ideal screenshot.
+- A disabled button is the only explanation for invalid input.
+- Client-side state is treated as proof of identity, access, payment, or completion.
+
+## Evidence before code
+
+- Main journey and alternate paths
+- UI state inventory
+- Validation and recovery behaviour
+- Accessibility acceptance criteria
+- Browser, device, network, and performance budgets
+
+## Ask an LLM or reviewer
+
+> “Walk through this UI as a first-time user, keyboard-only user, mobile user, impatient repeat-clicker, slow-network user, and user with stale data. List missing states and irreversible mistakes.”

--- a/AI Engineering Cheet series/smart_questions_before_you_build/03-data.md
+++ b/AI Engineering Cheet series/smart_questions_before_you_build/03-data.md
@@ -1,0 +1,42 @@
+# 03 — Data: Know What Is True
+
+> When two systems disagree, your architecture must already know which one wins.
+
+```mermaid
+flowchart TD
+    A["Source of truth"] --> B["Model + constraints"]
+    B --> C["Read/write paths"]
+    C --> D["Retention + deletion"]
+    D --> E["Backup + restore proof"]
+```
+
+## Stop and answer
+
+- [ ] What is authoritative for each data item, and which copies are caches, projections, indexes, or derived views?
+- [ ] What is the smallest model that correctly represents objects, ownership, relationships, states, and history?
+- [ ] Which uniqueness rules, references, and invariants must the database enforce?
+- [ ] How are concurrent updates, duplicates, stale versions, and late-arriving changes resolved?
+- [ ] How will schema changes remain compatible, be backfilled, monitored, and rolled back?
+- [ ] Which queries require indexes, pagination, limits, caching, batching, or archival?
+- [ ] Which personal, confidential, financial, or regulated fields are collected, and why is each necessary?
+- [ ] What consent, residency, retention, correction, export, deletion, and audit rules apply?
+- [ ] What consistency is required for each decision, read, write, and derived view?
+- [ ] What backup and recovery objectives apply, and when was a real restore last proven?
+
+## Warning signs
+
+- Several databases are called “the source of truth.”
+- Business invariants exist only as comments or UI validation.
+- The backup is monitored, but nobody has restored it.
+
+## Evidence before code
+
+- Data ownership map
+- Model, constraints, and lifecycle
+- Expected access patterns and query plans
+- Safe migration and rollback plan
+- Tested restore and data-repair path
+
+## Ask an LLM or reviewer
+
+> “Find contradictions in this data model. Test it against duplicates, concurrent edits, deletion requests, schema rollback, large growth, broken references, and disagreement between systems.”

--- a/AI Engineering Cheet series/smart_questions_before_you_build/04-events.md
+++ b/AI Engineering Cheet series/smart_questions_before_you_build/04-events.md
@@ -1,0 +1,48 @@
+# 04 — Events: Assume Delivery Gets Weird
+
+> Events can be late, duplicated, reordered, replayed, or never processed. Design for that before production teaches you.
+
+```mermaid
+sequenceDiagram
+    participant P as Producer
+    participant S as State store
+    participant Q as Queue
+    participant C as Consumer
+    P->>S: Commit business change
+    P->>Q: Publish event
+    Q-->>C: Deliver one or more times
+    C->>C: Validate + deduplicate
+    C->>S: Apply effect
+    C-->>Q: Acknowledge
+```
+
+## Stop and answer
+
+- [ ] What business fact does the event represent, and is an event better than a direct call or transaction?
+- [ ] Who produces it, who consumes it, and who owns its schema and meaning?
+- [ ] Which identifier, version, timestamp, tenant, actor, correlation ID, and causation ID must it carry?
+- [ ] Is delivery at-most-once, at-least-once, or effectively-once—and what does that mean for the business effect?
+- [ ] What happens when an event arrives late, twice, out of order, or after the underlying record changes?
+- [ ] What are the retry, backoff, expiry, dead-letter, poison-message, and replay rules?
+- [ ] How are database changes and event publication kept consistent when one succeeds and the other fails?
+- [ ] How can the schema change while old producers, stored events, and existing consumers remain active?
+- [ ] How are webhook signatures, event permissions, freshness, and replay protection verified?
+- [ ] How can an operator trace, repair, and safely replay one failed business transaction?
+
+## Warning signs
+
+- The event name describes a command, but consumers treat it as an immutable fact.
+- “The queue guarantees exactly once” replaces consumer idempotency.
+- Replaying an event can repeat a payment, email, entitlement, or inventory change.
+
+## Evidence before code
+
+- Event catalogue and owner
+- Schema and compatibility policy
+- Delivery, ordering, and idempotency rules
+- Retry, dead-letter, and replay procedure
+- Traceable example covering duplicate and out-of-order delivery
+
+## Ask an LLM or reviewer
+
+> “Break this event flow using duplicate, missing, late, reordered, forged, poisoned, and replayed messages. Show which business effects can happen twice or never happen.”

--- a/AI Engineering Cheet series/smart_questions_before_you_build/05-business.md
+++ b/AI Engineering Cheet series/smart_questions_before_you_build/05-business.md
@@ -1,0 +1,43 @@
+# 05 — Business Workflow: Trace What Actually Changes
+
+> Code succeeds only when the business outcome is correct—not when the endpoint returns 200.
+
+```mermaid
+flowchart LR
+    A["Actors"] --> B["Business rules"]
+    B --> C["Object states"]
+    C --> D["Business effects"]
+    D --> E["Outcome + risk"]
+    C -. failure .-> F["Retry, reverse, escalate"]
+```
+
+## Stop and answer
+
+- [ ] Which customers, employees, administrators, partners, providers, and internal systems participate?
+- [ ] Which business objects change: account, order, payment, booking, entitlement, document, or approval?
+- [ ] What states can each object occupy, and which transitions are allowed, forbidden, or irreversible?
+- [ ] What is the happy path from trigger to final business outcome, including hand-offs between actors?
+- [ ] Which rules must remain true during concurrency, retries, partial failure, and manual correction?
+- [ ] Which paths move money, grant access, consume inventory, create obligations, notify users, or expose data?
+- [ ] What happens when a user abandons, repeats, skips, reverses, or completes steps out of order?
+- [ ] Which failures require retry, refund, reversal, compensation, escalation, or human approval?
+- [ ] How could a customer, insider, partner, or bot accidentally or deliberately abuse the workflow?
+- [ ] Which outcome and risk metrics will reveal incorrect business behaviour after release?
+
+## Warning signs
+
+- The workflow starts at an API call instead of a business trigger.
+- Success is defined by technical completion, not the user’s final state.
+- Nobody owns refunds, reversals, stuck cases, or manual reconciliation.
+
+## Evidence before code
+
+- Actors and business objects
+- Valid states and forbidden outcomes
+- Happy, failure, retry, and recovery paths
+- Invariants and material business effects
+- Named owner for exceptions and manual operations
+
+## Ask an LLM or reviewer
+
+> “Act as a customer, operator, fraudster, finance owner, and support agent. Find missing states, skipped steps, duplicate effects, permission abuse, unrecoverable failures, and outcomes that look technically successful but are wrong for the business.”

--- a/AI Engineering Cheet series/smart_questions_before_you_build/06-system-design.md
+++ b/AI Engineering Cheet series/smart_questions_before_you_build/06-system-design.md
@@ -1,0 +1,43 @@
+# 06 — System Design: Make Boundaries and Failure Visible
+
+> Good architecture is not the most components. It is the clearest ownership with the smallest acceptable blast radius.
+
+```mermaid
+flowchart TD
+    A["Clients"] --> B["Interface boundary"]
+    B --> C["Core business capability"]
+    C --> D["Owned data"]
+    C --> E["Async work"]
+    C --> F["External dependencies"]
+```
+
+## Stop and answer
+
+- [ ] What is the smallest architecture that meets today’s requirement without blocking expected change?
+- [ ] Where are the system, ownership, trust, data, and external-dependency boundaries?
+- [ ] Which component owns each business rule and each piece of state?
+- [ ] What belongs in a synchronous request, background job, scheduled task, or event flow—and why?
+- [ ] What latency, throughput, concurrency, availability, recovery, and cost targets matter?
+- [ ] Where is strong consistency required, and where are stale reads or delayed processing acceptable?
+- [ ] What degraded behaviour is safe when a dependency is slow, unavailable, rate-limited, or inconsistent?
+- [ ] Which timeouts, queues, quotas, isolation boundaries, and kill switches contain failure?
+- [ ] What breaks first at 2×, 5×, and 10× expected usage, and which single points of failure remain?
+- [ ] Can another engineer understand, operate, replace, or evolve each component from recorded decisions?
+
+## Warning signs
+
+- Components are separated by technology, but business ownership is still ambiguous.
+- Availability and scale are described as “high” without numbers.
+- Every dependency failure becomes a full-system failure.
+
+## Evidence before code
+
+- Component and ownership map
+- Request, event, and data paths
+- Capacity and consistency assumptions
+- Failure containment and degraded modes
+- Decision record with rejected alternatives
+
+## Ask an LLM or reviewer
+
+> “Review this design for unnecessary components, unclear ownership, hidden coupling, inconsistent state, cascading failure, capacity limits, and expensive operations. Propose the simplest credible alternative.”

--- a/AI Engineering Cheet series/smart_questions_before_you_build/07-devops.md
+++ b/AI Engineering Cheet series/smart_questions_before_you_build/07-devops.md
@@ -1,0 +1,43 @@
+# 07 — DevOps: Design the Release and the Recovery
+
+> “It works locally” is the start of deployment work, not the end of engineering.
+
+```mermaid
+flowchart LR
+    A["Commit"] --> B["Build artifact"]
+    B --> C["Quality gates"]
+    C --> D["Progressive deploy"]
+    D --> E["Observe"]
+    E -. unhealthy .-> F["Stop or roll back"]
+```
+
+## Stop and answer
+
+- [ ] Where will the system run, and how does an approved commit become a traceable artifact?
+- [ ] Can development, test, staging, and production be reproduced with explicit differences?
+- [ ] How are configuration and secrets delivered, validated, scoped, and rotated?
+- [ ] Which endpoints, ports, storage systems, and administration surfaces are reachable, and from where?
+- [ ] Which health, readiness, and dependency checks control traffic and rollout decisions?
+- [ ] How are application, worker, event-schema, and database changes ordered safely?
+- [ ] What rollout strategy limits exposure, and what signal automatically pauses it?
+- [ ] How quickly can a bad release be stopped or reversed if data has already changed?
+- [ ] What scales automatically, and which quota, cost, dependency, or resource fails first?
+- [ ] Can the environment be rebuilt after loss, and who owns releases, credentials, cost, and recovery?
+
+## Warning signs
+
+- Deployment and rollback are undocumented sequences known by one person.
+- A health check says “up” while dependencies or business workflows are broken.
+- Rollback assumes the database can move backward after irreversible writes.
+
+## Evidence before code
+
+- Build-to-deploy path
+- Environment and configuration model
+- Exposure and health-check inventory
+- Rollout, stop, migration, and rollback plan
+- Rebuild, restore, cost, and ownership proof
+
+## Ask an LLM or reviewer
+
+> “Simulate a bad release, failed migration, leaked configuration, unhealthy dependency, capacity spike, and lost environment. Identify where deployment cannot stop safely or recovery depends on tribal knowledge.”

--- a/AI Engineering Cheet series/smart_questions_before_you_build/08-security.md
+++ b/AI Engineering Cheet series/smart_questions_before_you_build/08-security.md
@@ -1,0 +1,43 @@
+# 08 — Security: Distrust Every Boundary
+
+> Ask not only “Can an attacker get in?” Ask “What trusted action can be abused after they do?”
+
+```mermaid
+flowchart TD
+    A["Untrusted input"] --> B["Validate"]
+    B --> C["Authenticate"]
+    C --> D["Authorise resource + action"]
+    D --> E["Execute with limits"]
+    E --> F["Audit + detect abuse"]
+```
+
+## Stop and answer
+
+- [ ] What are the most valuable assets, sensitive operations, likely attackers, and trust boundaries?
+- [ ] Who may perform each action on each resource, and where is that decision enforced?
+- [ ] How are files, URLs, text, queries, headers, rendered content, webhooks, and other inputs constrained?
+- [ ] Where could credentials, personal data, confidential content, or tokens leak through logs, errors, analytics, caches, prompts, or exports?
+- [ ] Are credentials narrowly scoped, separated by tenant/environment, short-lived where possible, rotatable, and auditable?
+- [ ] How could retries, races, bulk actions, invitations, refunds, recovery flows, or quotas be abused?
+- [ ] What privacy, consent, residency, retention, deletion, accessibility, licence, and sector obligations apply?
+- [ ] Which vendors, dependencies, datasets, models, and build artifacts introduce supply-chain or data-sharing risk?
+- [ ] What tamper-resistant evidence records access, approvals, state changes, administrator actions, and configuration changes?
+- [ ] How will an incident be detected, contained, investigated, communicated, and recovered from?
+
+## Warning signs
+
+- Possession of a client token, email address, or hidden URL is treated as authorisation.
+- Secrets are removed from source but still appear in logs, prompts, or build output.
+- Rate limits control traffic volume but not costly or high-impact business actions.
+
+## Evidence before code
+
+- Assets, actors, entry points, and trust boundaries
+- Resource-level permission matrix
+- Abuse cases and blast-radius controls
+- Data flow, vendor, licence, and compliance review
+- Audit and incident-response plan
+
+## Ask an LLM or reviewer
+
+> “Threat-model this change as an unauthorised user, compromised account, malicious insider, automated abuser, forged webhook, poisoned dependency, and data-exfiltration attempt. Rank attack paths by impact and plausibility.”

--- a/AI Engineering Cheet series/smart_questions_before_you_build/09-testing.md
+++ b/AI Engineering Cheet series/smart_questions_before_you_build/09-testing.md
@@ -1,0 +1,42 @@
+# 09 — Testing: Test Risk, Not Just Code
+
+> A test suite is useful when it catches the failures you cannot afford to ship.
+
+```mermaid
+flowchart TD
+    A["Business + user risk"] --> B["Critical behaviours"]
+    B --> C["Right test level"]
+    C --> D["Failure + edge cases"]
+    D --> E["Release evidence"]
+```
+
+## Stop and answer
+
+- [ ] Which wrong behaviour would create the greatest user, business, security, financial, or operational damage?
+- [ ] Which rules need unit tests and which boundaries need contract, integration, end-to-end, load, security, or recovery tests?
+- [ ] Are success, boundary, empty, malformed, denied, duplicate, concurrent, timeout, cancellation, and dependency-failure cases covered?
+- [ ] Do tests verify the final business effect and persisted state—not only status codes, mocks, or snapshots?
+- [ ] Are critical tests deterministic, isolated, repeatable, understandable, and independent of execution order?
+- [ ] Where could mocks hide real database, queue, browser, network, clock, provider, or concurrency behaviour?
+- [ ] Which lint, type, secret, dependency, licence, migration, and security checks must block integration or release?
+- [ ] What realistic data volume, load, device, network, and fault injection is required?
+- [ ] Which behaviours require a production-like environment, exploratory testing, accessibility review, or domain expert?
+- [ ] If the core behaviour were deliberately broken, would the suite fail for the correct reason?
+
+## Warning signs
+
+- Coverage percentage is treated as proof of correctness.
+- Tests confirm internal calls but never check the business outcome.
+- Flaky tests are retried until green instead of diagnosed.
+
+## Evidence before code
+
+- Risk-ranked behaviour list
+- Test level chosen for each important boundary
+- Realistic fixtures and failure cases
+- Blocking quality gates
+- Named production-like and human checks
+
+## Ask an LLM or reviewer
+
+> “Given these requirements and workflows, produce a risk-ranked test strategy. Find missing boundary, failure, concurrency, permission, recovery, and abuse cases. Explain what mocks cannot prove.”

--- a/AI Engineering Cheet series/smart_questions_before_you_build/10-observability.md
+++ b/AI Engineering Cheet series/smart_questions_before_you_build/10-observability.md
@@ -1,0 +1,42 @@
+# 10 — Observability: Make Failure Explain Itself
+
+> If users can feel a failure but operators cannot see it, the system is not observable.
+
+```mermaid
+flowchart LR
+    A["User or business symptom"] --> B["Logs, metrics, traces"]
+    B --> C["Actionable alert"]
+    C --> D["Diagnosis"]
+    D --> E["Recover + learn"]
+```
+
+## Stop and answer
+
+- [ ] Which user-visible and business-visible symptoms mean the feature is unhealthy even when servers are running?
+- [ ] Which structured logs, traces, event metadata, and correlation IDs explain one operation end to end?
+- [ ] Which latency, traffic, error, saturation, queue, dependency, cost, and outcome metrics matter?
+- [ ] Which silent failures—stalled jobs, dropped events, delayed workflows, partial writes, missing notifications, or drift—need detection?
+- [ ] What service-level objectives or error budgets define acceptable reliability?
+- [ ] Which alerts require action, who receives them, and what decision or runbook follows?
+- [ ] Can operators distinguish code failure from dependency failure, bad data, bad configuration, exhausted capacity, and user misuse?
+- [ ] Can failed work be inspected, retried, replayed, cancelled, compensated, or quarantined safely?
+- [ ] Is telemetry useful without leaking secrets, personal data, or confidential payloads—or creating uncontrolled cost?
+- [ ] Can the team inject a realistic failure and diagnose and recover using only its signals and runbooks?
+
+## Warning signs
+
+- Dashboards show server health but no completed business outcomes.
+- Alerts describe symptoms without an owner or next action.
+- Logs are either too vague to diagnose or so detailed they expose sensitive data.
+
+## Evidence before code
+
+- User, technical, and business signals
+- End-to-end correlation plan
+- SLOs, dashboards, and actionable alerts
+- Safe retry/replay/cancellation controls
+- Failure drill and owned runbooks
+
+## Ask an LLM or reviewer
+
+> “Assume this system fails silently at 3 a.m. Show which signals reveal the user impact, where diagnosis loses correlation, which alerts are noisy or missing, and what recovery action operators still lack.”


### PR DESCRIPTION
## What changed

- Added 11 focused Markdown cheat sheets under `AI Engineering Cheet series/smart_questions_before_you_build/`.
- Covered requirements, backend, frontend, data, events, business workflows, system design, DevOps, security, testing, and observability.
- Included one compact Mermaid visual, 10 pre-build questions, warning signs, required evidence, and an LLM/reviewer prompt in every file.
- Removed the requested Socratic attribution footer from all files.

## Why

The series gives engineers a practical set of questions to ask themselves, an LLM, and relevant reviewers before implementation begins.

## Validation

- Confirmed all 11 files exist at the requested repository path.
- Confirmed each file contains 10 checklist questions and one balanced Mermaid code block.
- Confirmed the removed footer text does not appear in any file.
- Compared each committed Git blob with its local source file.