### PR TITLE
[Challenge 2026][Track C] Add specific host allowlist guidance to TROUBLESHOOTING.md

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -42,6 +42,14 @@ python3 -m unvibecode review --repository "/Users/example/My Repository"
 
 Confirm that the computer has internet access and that organizational firewall rules allow HTTPS access to the hosted UnvibeCode service.
 
+If the terminal shows `403 Client Error` for `openaipublic.blob.core.windows.net`, or `Host not in allowlist` for `shipready-api.alphashots.ai`, your network is blocking specific hosts UnvibeCode needs rather than blocking all outbound traffic. Ask your network administrator to allow HTTPS access to:
+
+- `openaipublic.blob.core.windows.net` (tokenizer data)
+- `shipready-api.alphashots.ai` (business workflow and risk review)
+
+Re-run the same command after access is allowed;
+UnvibeCode does not need to be reinstalled.
+
 ## Only the Connected Code Map was produced
 
 Repositories above approximately two million estimated source tokens intentionally receive the Connected Code Map and Complete Repository Context without the deeper Business Workflow and Risk Review.


### PR DESCRIPTION

## Problem

The "Hosted analysis cannot connect" section tells users to allow HTTPS access to "the hosted UnvibeCode service" but does not name which hosts. Users on restricted or corporate networks cannot ask their network admin to open access without knowing the exact hostnames, and the actual errors (403 on the tokenizer blob, and "Host not in allowlist" for the risk-review API) don't map obviously back to this section.

## What I changed

- Added the two specific hostnames UnvibeCode needs (tokenizer + business review API)
- Added the exact error text a user will see for each, so they can find this section by searching the error message

## Files changed

- docs/TROUBLESHOOTING.md

## Checked

- Commands/hostnames are correct (reproduced both errors while testing)
- Markdown links work
- GitHub Quality Checks passed

## Problem and scope

Describe the user problem and the focused scope of this change.

## What changed

Summarize the implementation or content change.

## Verification

List the commands, fixtures, public repositories, and outputs used to verify the change.

- [ ] `python -m black --config .github/quality/pyproject.toml --check .github/quality/tests`
- [ ] `python -m flake8 --config .github/quality/.flake8 .github/quality/tests`
- [ ] `python -m pytest -c .github/quality/pyproject.toml .github/quality/tests`
- [ ] I used UnvibeCode on a representative repository when the change affects code analysis, CLI behaviour, engineering guidance, or code-specific claims.
- [ ] I updated documentation for changed user-facing behaviour.
- [ ] I included no credentials, proprietary source, customer data, generated customer reports, or unsanitized logs.

## Workflow-pack checks

Complete these items only when adding or changing a pre-built workflow pack.

- [ ] The start, end, included scope, and excluded scope are explicit.
- [ ] The pack owns one primary business outcome and does not duplicate an existing pack.
- [ ] The 20 core scenarios are distinct and collectively cover the declared boundary.
- [ ] Every core scenario states what must not happen.
- [ ] All 13 required files use consistent `People and systems`, `Things created or changed`, `Stages`, and outcome names.

## Remaining limitations

List any known limitation or follow-up issue.
