### PR TITLE
[Challenge 2026][Improvement] Validate required core scenario content

### DIFF
--- a/.github/quality/tests/test_repository_quality.py
+++ b/.github/quality/tests/test_repository_quality.py
@@ -55,6 +55,30 @@ def test_workflow_pack_has_exactly_twenty_core_scenarios(pack):
 
 
 @pytest.mark.parametrize("pack", workflow_packs(), ids=lambda path: path.name)
+def test_workflow_pack_core_scenarios_have_required_content(pack):
+    content = (pack / "CORE_20_SCENARIOS.md").read_text(encoding="utf-8")
+
+    rows = []
+    for line in content.splitlines():
+        if not re.match(r"^\|\s*\d+\s*\|", line):
+            continue
+
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        rows.append(cells)
+
+    assert len(rows) == 20
+
+    for row in rows:
+        assert len(row) == 3
+        number, scenario, must_not_happen = row
+        assert number.isdigit()
+        assert scenario, f"Scenario {number} has no scenario description"
+        assert (
+            must_not_happen
+        ), f"Scenario {number} has no 'Must not happen' description"
+
+
+@pytest.mark.parametrize("pack", workflow_packs(), ids=lambda path: path.name)
 def test_workflow_skills_have_frontmatter(pack):
     for filename in SKILL_FILES:
         content = (pack / filename).read_text(encoding="utf-8")


### PR DESCRIPTION
## Problem and scope

The current quality check confirms that workflow packs contain scenarios numbered 1 through 20, but it does not check whether the individual scenario rows are actually complete.

That leaves a gap where a scenario could have its number but be missing the description or the outcome that explains what should not happen.

This PR adds a focused check for that missing validation. It only affects the repository quality tests and does not change any workflow-pack content.

## What changed

I added a parametrized test to `test_repository_quality.py`.

For every workflow pack, the test reads the `CORE_20_SCENARIOS.md` table and checks that all 20 scenario rows have:

* a valid scenario number;
* a scenario description;
* a non-empty `Must not happen` value.

The existing test for the 1–20 numbering remains unchanged.

## Verification

I first ran the existing test suite before making the change and got:

`600 passed`

After adding the validation, the full suite reported:

`620 passed`

I also ran:

* `python -m black --config .github/quality/pyproject.toml --check .github/quality/tests`
* `python -m flake8 --config .github/quality/.flake8 .github/quality/tests`
* `python -m pytest -c .github/quality/pyproject.toml .github/quality/tests`
* `git diff --check`

All of these completed successfully.

To check that the new validation was actually catching the intended problem, I temporarily removed the third field from one scenario. The focused test then failed with a two-field-versus-three-field assertion for that workflow pack. I restored the original scenario afterward, and the complete suite returned to `620 passed`.

The verification was performed on Windows with Python 3.12.3 and pytest 9.1.1.

* [x] `python -m black --config .github/quality/pyproject.toml --check .github/quality/tests`
* [x] `python -m flake8 --config .github/quality/.flake8 .github/quality/tests`
* [x] `python -m pytest -c .github/quality/pyproject.toml .github/quality/tests`
* [ ] I used UnvibeCode on a representative repository when the change affects code analysis, CLI behaviour, engineering guidance, or code-specific claims.
* [ ] I updated documentation for changed user-facing behaviour.
* [x] I included no credentials, proprietary source, customer data, generated customer reports, or unsanitized logs.

## Workflow-pack checks

Not applicable. I did not add, remove, or modify any workflow pack.

## Remaining limitations

This check verifies that the required table fields exist and contain text. It does not determine whether the scenario itself is well-written, unique, or semantically complete.
