### PR TITLE
[Improvement] Add Windows CMD activation instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,6 +36,11 @@ On Windows PowerShell, activate the environment with:
 ```powershell
 .venv\Scripts\Activate.ps1
 ```
+On Windows Command Prompt (CMD), activate the environment with:
+
+```cmd
+.venv\Scripts\activate.bat
+```
 
 Run the same checks used in pull requests:
 


### PR DESCRIPTION
## Summary

Adds Windows Command Prompt (CMD) activation instructions to the contribution guide.

## Change

Added:

```cmd
.venv\Scripts\activate.bat