### PR TITLE
feat(workflow-pack): add Agentic Tool Execution and Permission Bounda…

### DIFF
--- a/prebuilt-workflow-paths/README.md
+++ b/prebuilt-workflow-paths/README.md
@@ -58,6 +58,7 @@ No installation, generator, schema, or build step is required. Every workflow is
 
 | Workflow | Use it when your application… |
 |---|---|
+| [Agentic Tool Execution and Permission Boundary](agentic-tool-execution-and-permission-boundary/) | executes agentic tool calls with schema validation, permission bounds, and sandboxing |
 | [LLM Content Generation and Structured-output Validation](llm-content-generation-and-output-validation/) | generates content or structured results and must validate them before use |
 | [RAG Question Answering with Evidence and Citations](rag-question-answering-with-evidence-and-citations/) | retrieves sources and produces answers that must remain grounded in evidence |
 | [External-system Synchronization and Checkpointing](external-system-data-sync-and-checkpointing/) | synchronizes records with an external system while tracking progress and recovery |
@@ -129,10 +130,10 @@ Read the [repository contribution guide](../.github/CONTRIBUTING.md) before prop
 
 ## Collection summary
 
-- 18 independently usable business workflow packs
-- 234 workflow-specific Markdown files
-- 360 compact core scenarios
-- 360 complete Given/When/Expect scenario descriptions
-- 90 portable task skills
+- 19 independently usable business workflow packs
+- 247 workflow-specific Markdown files
+- 380 compact core scenarios
+- 380 complete Given/When/Expect scenario descriptions
+- 95 portable task skills
 
 These packs are starting points for application-specific analysis. Product rules, laws, provider contracts, data-retention requirements, and operational limits still need to be adapted to the repository being reviewed.

--- a/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/CORE_20_SCENARIOS.md
+++ b/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/CORE_20_SCENARIOS.md
@@ -1,0 +1,26 @@
+# Core 20 Scenarios
+
+| # | Scenario | Must not happen |
+|---:|---|---|
+| 1 | Valid tool request with complete arguments executes successfully | Tool output is lost or malformed result reaches the agent |
+| 2 | Unregistered tool name is requested | Arbitrary command or unapproved function is invoked |
+| 3 | Tool arguments violate JSON schema | Unvalidated payload triggers runtime unhandled crash |
+| 4 | High-risk tool requires human approval | Destructive side effect runs without explicit user confirmation |
+| 5 | Human rejects tool confirmation prompt | Rejected tool executes anyway or session hangs |
+| 6 | Requester session lacks required permission scope | Escalated tool action modifies unauthorized tenant resources |
+| 7 | Prompt injection in argument payload attempts command injection | Host shell commands or path traversal execute |
+| 8 | Tool execution exceeds allotted CPU time limit | Long-running task blocks worker pool indefinitely |
+| 9 | Tool execution exceeds RAM allocation | Out-of-memory error crashes host orchestrator process |
+| 10 | Tool returns sensitive internal credentials | Raw tokens or private secrets leak into LLM context |
+| 11 | External API dependency fails during execution | Failure causes cascade crash without structured error return |
+| 12 | Duplicate tool request submitted concurrently | Idempotent operation runs multiple times producing duplicate side effects |
+| 13 | Maximum tool call iteration depth reached | Infinite agent loop consumes system budget and rate limits |
+| 14 | Network access restricted to allowlisted endpoints | Tool connects to unauthorized internal subnet or metadata IP |
+| 15 | Partial tool execution fails mid-operation | Incomplete database changes persist without rollback |
+| 16 | Tool output exceeds maximum response size | Unbounded response crashes context memory parser |
+| 17 | Tool invocation audit logging fails | Tool executes without leaving verifiable audit evidence |
+| 18 | Session revoked while tool execution in progress | Disconnected user session receives finished tool output |
+| 19 | Rate limit reached for targeted tool | Exceeded limit allows request flooding or resource starvation |
+| 20 | Tool execution retries after transient failure | Retry bypasses permission check or duplicates non-idempotent action |
+
+Full details are in [TESTING_GUIDE.md](TESTING_GUIDE.md).

--- a/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/ENGINEERING_GUIDE.md
+++ b/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/ENGINEERING_GUIDE.md
@@ -1,0 +1,26 @@
+# Engineering Guide
+
+## Architecture and Components
+
+The tool execution system acts as a secure proxy layer between non-deterministic LLM output and internal infrastructure.
+
+```text
++----------------+      +-------------------+      +-------------------+      +------------------+
+| LLM Controller | ---> | Tool Registry     | ---> | Authorization &   | ---> | Execution        |
+| (Function Call)|      | (Schema Validator)|      | HITL Consent Gate |      | Sandbox / Worker |
++----------------+      +-------------------+      +-------------------+      +------------------+
+                                                                                       |
+                                                                                       v
+                                                                              +------------------+
+                                                                              | Output Filter &  |
+                                                                              | Audit Log Engine |
+                                                                              +------------------+
+```
+
+## Key Technical Controls
+
+1. **Schema Enforcement**: Input arguments must strictly adhere to Pydantic/JSON schemas. Unknown parameters or type coercions must fail closed.
+2. **Permission Boundary**: Tool definitions declare required scopes (e.g., `read:files`, `write:database`). Execution fails if the session context lacks matching claims.
+3. **Resource Caps**: Executions are limited by strict timeouts (e.g., 10 seconds), max memory (e.g., 256MB), and bounded output tokens.
+4. **Credential Decoupling**: Tools receive scoped, short-lived tokens or worker secrets injected at execution time, never raw long-lived user credentials.
+5. **Output Filtering**: Result text passes through regex redactors to prevent secret leak (JWTs, AWS keys, private IPs) back to LLM context.

--- a/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/IMPLEMENT_WORKFLOW_SKILL.md
+++ b/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/IMPLEMENT_WORKFLOW_SKILL.md
@@ -1,0 +1,14 @@
+---
+name: implement-agentic-tool-execution-workflow
+description: Implement features or fixes for Agentic Tool Execution and Permission Boundary. Use when building tool registration, schema validators, sandboxing isolation, human approvals, or secret redactors.
+---
+
+# Implement Agentic Tool Execution Workflow
+
+Follow architecture guidelines during implementation:
+- Implement strict JSON schema validation for all tool arguments using validated Pydantic or JSONSchema parsers
+- Enforce explicit authorization scope verification before dispatching tool tasks
+- Add human approval confirmation workflows for destructive or side-effecting tools
+- Isolate tool process execution using container sandboxes or restricted process environments
+- Apply regex secret redactors to tool outputs before returning responses to orchestrators or logs
+- Implement timeout limits and recursion counters to prevent resource exhaustion

--- a/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/PATHS_AND_EDGE_CASES.md
+++ b/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/PATHS_AND_EDGE_CASES.md
@@ -1,0 +1,17 @@
+# Paths and Edge Cases
+
+## Complex Workflow Paths
+
+1. **Multi-Tool Chaining**: The agent requests `tool_A` followed immediately by `tool_B` using `tool_A` output.
+   - *Control*: Each step in the chain re-evaluates session permissions and timeout budgets. Context size is checked prior to passing output downstream.
+2. **Asynchronous Long-Running Execution**: A tool triggers a batch job taking longer than synchronous HTTP response windows.
+   - *Control*: Tool returns a `task_id` with status `PENDING`. The orchestrator polls or listens for webhook completion rather than holding open socket connections.
+
+## Boundary Edge Cases
+
+- **Non-Serializable Returns**: Tool returns complex Python/Go objects (e.g., raw sockets, circular refs) that fail JSON encoding.
+  - *Handling*: Handlers convert outputs to primitive dicts or stringify via fallbacks before passing to the output filter.
+- **Interrupted User Sessions**: The user closes the UI tab while an interactive HITL approval prompt is pending.
+  - *Handling*: Pending approval tokens automatically expire after a configurable TTL (e.g., 5 minutes), aborting execution cleanly.
+- **Concurrent Identical Calls**: Two agent threads request the exact same mutation tool simultaneously.
+  - *Handling*: Idempotency keys bound to the request hash prevent double execution.

--- a/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/PERMISSION_AND_ABUSE_GUIDE.md
+++ b/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/PERMISSION_AND_ABUSE_GUIDE.md
@@ -1,0 +1,18 @@
+# Permission and Abuse Guide
+
+## Security Threat Model
+
+Agentic tool execution introduces unique threat vectors due to the non-deterministic nature of LLM reasoning and susceptibility to indirect prompt injection.
+
+| Vulnerability / Threat Vector | Attack Scenario | Prevention Control |
+|---|---|---|
+| Indirect Prompt Injection | Malicious website contents instruct agent to call `send_email` with internal data | Strict HITL approval for external data transmission tools |
+| SSRF (Server-Side Request Forgery) | Agent tool takes URL argument and requests `http://169.254.169.254/latest/meta-data` | Network egress allowlisting and metadata IP blocking |
+| Privilege Escalation | User tricks agent into invoking admin-only maintenance tool | Fine-grained RBAC evaluation per tool call session token |
+| Resource Exhaustion (DoS) | Agent trapped in endless tool calling loop | Iteration caps (max 10 tool steps per user turn) |
+| Environment Variable Theft | Tool script prints `process.env` | Micro-container isolation with stripped environment |
+
+## Abuse Monitoring
+
+- Track tool invocation velocity per user session. Trigger rate limiting if tool requests exceed 30 per minute.
+- Flag repeated schema validation failures as potential automated fuzzing attacks.

--- a/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/PRODUCT_AND_BUSINESS_GUIDE.md
+++ b/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/PRODUCT_AND_BUSINESS_GUIDE.md
@@ -1,0 +1,37 @@
+# Product and Business Guide
+
+## Overview
+
+The Agentic Tool Execution and Permission Boundary workflow governs how autonomous LLM agents invoke functions, APIs, database operations, shell tools, or external services on behalf of users. When an LLM model generates a function call request, the workflow validates the tool payload against registered schemas, checks authorization policies, enforces human confirmation for destructive side effects, executes the tool within an isolated environment, and returns sanitized, audit-logged results.
+
+## People and systems
+
+- **User**: The human requester initiating the AI session or approving high-risk tool operations.
+- **LLM Controller / Agent Orchestrator**: The backend orchestrator parsing LLM function-call outputs and scheduling execution.
+- **Tool Registry**: The central registry storing tool definitions, JSON schemas, permission scopes, and execution handlers.
+- **Execution Sandbox / Handler**: The runtime environment (e.g., container, process isolate, restricted worker) running tool logic.
+- **Audit & Compliance System**: Immutable log recording tool invocations, inputs, approvals, execution duration, and outcomes.
+
+## Things created or changed
+
+- **Tool Execution Request**: A structured invocation payload with tool name, arguments, session ID, and trace context.
+- **Permission & Consent Token**: Verified record confirming the user or system authorized the tool invocation.
+- **Sandbox Container / Worker**: Transient isolated environment provisioned for running side-effecting code.
+- **Tool Execution Result**: Validated output, status code, or structured error returned to the orchestrator.
+- **Audit Log Record**: Timestamped, sanitized log entry capturing tool parameters and side-effect evidence.
+
+## Stages
+
+1. **Invocation Request**: The LLM agent requests execution of a named tool with argument payload.
+2. **Schema & Policy Validation**: Arguments are validated against the tool's JSON schema and role-based access rules.
+3. **Approval Gating**: Destructive or high-risk tools trigger a human-in-the-loop (HITL) prompt or confirmation step.
+4. **Execution & Sandboxing**: The tool runs in an isolated container with CPU, memory, and network constraints.
+5. **Output Sanitization & Hand-off**: Results are filtered to remove sensitive credentials or raw tracebacks, then returned to the LLM agent.
+
+## Must not happen
+
+- **Unauthorized Action Execution**: A tool executes an operation exceeding the user's role permissions.
+- **Unbounded Side Effects**: An unapproved tool modifies, deletes, or transfers data without explicit user confirmation.
+- **Sandbox Escape / Privilege Escalation**: Tool execution breaks out of runtime bounds or accesses host environment variables.
+- **Credential Leakage**: Internal API keys, tokens, or raw database connection strings are returned to the LLM or audit logs.
+- **Infinite Recursive Loop**: An agent continuously re-invokes failing tools without iteration caps or circuit breakers.

--- a/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/README.md
+++ b/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/README.md
@@ -1,0 +1,28 @@
+# Agentic Tool Execution and Permission Boundary
+
+Starts when an AI agent or LLM controller requests the execution of a registered tool call with specific arguments on behalf of an authenticated user session. Ends when the tool execution finishes safely, returns validated and sanitized output to the agent controller, or is explicitly blocked, sandboxed, or timed out without unauthorized side effects, data leakage, or unhandled permission escalation.
+
+| Task | File |
+|---|---|
+| Product and business | [PRODUCT_AND_BUSINESS_GUIDE.md](PRODUCT_AND_BUSINESS_GUIDE.md) |
+| Engineering | [ENGINEERING_GUIDE.md](ENGINEERING_GUIDE.md) |
+| Testing | [TESTING_GUIDE.md](TESTING_GUIDE.md) |
+| Core 20 | [CORE_20_SCENARIOS.md](CORE_20_SCENARIOS.md) |
+| Paths and edge cases | [PATHS_AND_EDGE_CASES.md](PATHS_AND_EDGE_CASES.md) |
+| Permissions and misuse | [PERMISSION_AND_ABUSE_GUIDE.md](PERMISSION_AND_ABUSE_GUIDE.md) |
+| Retry and recovery | [RETRY_AND_RECOVERY_GUIDE.md](RETRY_AND_RECOVERY_GUIDE.md) |
+
+## Included
+- tool discovery, registration, argument parsing, JSON schema validation, and instruction bounds
+- user consent, human-in-the-loop (HITL) approval, action confirmation, and permission check
+- execution sandboxing, timeout enforcement, memory bounds, rate limiting, and process isolation
+- credential isolation, secret injection, output sanitization, error wrapping, and audit logging
+- prompt injection resistance in tool arguments, recursive tool loop limits, and side-effect gating
+
+## Excluded
+- prompt template assembly and LLM content generation
+- vector retrieval and document chunking
+- payment authorization and external gateway billing
+- user identity authentication and OAuth token issuance
+
+The five `*_SKILL.md` files are self-contained.

--- a/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/RETRY_AND_RECOVERY_GUIDE.md
+++ b/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/RETRY_AND_RECOVERY_GUIDE.md
@@ -1,0 +1,12 @@
+# Retry and Recovery Guide
+
+## Transient Failure Management
+
+1. **Network Retries**: For read-only tools connecting to external APIs, implement exponential backoff with jitter (max 3 retries, base delay 500ms).
+2. **Non-Idempotent Mutations**: Never automatically retry tools with state-changing side effects (e.g., `process_payment`, `send_sms`) unless an explicit idempotency key was confirmed by the downstream target.
+3. **Sandbox Recovery**: If a worker sandbox process crashes due to memory overflow, terminate the container cleanly, mark the execution as `FAILED_SANDBOX`, and return a graceful error message to the orchestrator to prevent container leakage.
+
+## Recovery Procedures
+
+- **Stuck State Cleanup**: A background reaper process scans for tool executions stuck in `RUNNING` status longer than 60 seconds and marks them `TIMED_OUT`.
+- **Fallbacks**: When a primary tool fails, the orchestrator may return a structured error payload advising the LLM of the specific constraint rather than throwing an unhandled exception.

--- a/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/REVIEW_BUSINESS_RISK_SKILL.md
@@ -1,0 +1,15 @@
+---
+name: review-agentic-tool-execution-risk
+description: Review business risks in Agentic Tool Execution and Permission Boundary implementations. Use when identifying unauthorized actions, sandbox escapes, unvalidated arguments, secret leaks, missing HITL approvals, or unhandled tool failures.
+---
+
+# Review Agentic Tool Execution Business Risks
+
+Analyze implementation code for tool calling and security boundaries:
+- Verify that tool input arguments are strictly validated against JSON schemas before execution
+- Check that role-based access control (RBAC) is enforced for every tool invocation session
+- Ensure destructive or high-risk tool operations require explicit human confirmation
+- Confirm that tool execution occurs within an isolated sandbox environment with resource limits
+- Verify that output sanitization filters strip internal secrets or private API tokens before returning data to LLM context
+- Check for loop controls that prevent recursive tool invocation storms
+- Verify audit log integrity for all side-effecting operations

--- a/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/TESTING_GUIDE.md
+++ b/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/TESTING_GUIDE.md
@@ -1,0 +1,24 @@
+# Testing Guide
+
+## Validation Strategy
+
+Testing tool execution and permission boundaries requires unit, integration, and security tests spanning happy paths, parameter validation, authorization boundaries, sandboxing, and fault tolerance.
+
+## Test Suites and Scenarios
+
+### 1. Happy Path & Schema Validation Tests
+- **Valid Tool Call**: Execute a registered tool (e.g., `search_database`) with schema-compliant JSON. Assert HTTP 200/success status and structured JSON response.
+- **Invalid Parameters**: Supply missing required fields or incorrect types. Verify 400 Validation Error and zero tool invocation.
+
+### 2. Authorization & Human-in-the-Loop Tests
+- **Scope Enforcement**: Invoke a write tool (e.g., `delete_record`) with a read-only session token. Assert HTTP 403 Forbidden.
+- **HITL Confirmation**: Trigger a high-risk tool. Verify execution pauses until approval token is posted; verify rejection aborts execution without side effects.
+
+### 3. Sandboxing & Security Boundary Tests
+- **Command Injection Prevention**: Pass arguments containing shell characters (`; rm -rf /`, `$(whoami)`). Verify arguments are properly escaped or rejected.
+- **Path Traversal Isolation**: Pass file paths like `../../etc/passwd`. Assert access is strictly restricted to sandbox workdir.
+- **Secret Redaction**: Mock tool returning `{"api_key": "sk-proj-12345"}`. Assert output filter redacts key to `[REDACTED_SECRET]`.
+
+### 4. Resiliency & Failure Recovery Tests
+- **Timeout Termination**: Force a test tool handler to sleep 30s when max timeout is 5s. Assert execution terminates cleanly with timeout error.
+- **Circuit Breaking**: Simulate 5 consecutive tool failures. Verify circuit breaker opens and rejects subsequent calls instantly.

--- a/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/TEST_WORKFLOW_SKILL.md
+++ b/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/TEST_WORKFLOW_SKILL.md
@@ -1,0 +1,14 @@
+---
+name: test-agentic-tool-execution-workflow
+description: Test features, edge cases, and security boundaries for Agentic Tool Execution and Permission Boundary. Use when writing unit, integration, or security tests for tool invocation and sandboxing.
+---
+
+# Test Agentic Tool Execution Workflow
+
+Design comprehensive test suites:
+- Test valid tool execution returns expected schema-compliant JSON payloads
+- Test invalid argument payloads trigger immediate HTTP 400 validation failures
+- Test unauthorized session tokens receive HTTP 403 Forbidden responses
+- Test human approval rejection halts tool execution without side effects
+- Test timeout enforcement terminates long-running tool processes cleanly
+- Test output redactors filter API secrets and raw connection strings from results

--- a/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/UNDERSTAND_CODE_SKILL.md
+++ b/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/UNDERSTAND_CODE_SKILL.md
@@ -1,0 +1,13 @@
+---
+name: understand-agentic-tool-execution-code
+description: Trace and understand code implementing Agentic Tool Execution and Permission Boundary. Use when mapping tool registries, execution handlers, permission checks, sandbox boundaries, or response formatters.
+---
+
+# Understand Agentic Tool Execution Code
+
+Trace code paths for agent tool execution:
+- Locate tool registration definitions, schema metadata, and entry point handlers
+- Identify authorization middleware, token claim validation, and permission checks
+- Trace human-in-the-loop (HITL) prompt generation, token issuance, and approval callback handlers
+- Identify sandboxing containers, subprocess invocation, resource limit settings, and environment isolation
+- Trace output filtering, regex secret scrubbers, error formatters, and audit log dispatchers

--- a/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/WRITE_PRODUCT_SPEC_SKILL.md
+++ b/prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/WRITE_PRODUCT_SPEC_SKILL.md
@@ -1,0 +1,17 @@
+---
+name: write-agentic-tool-execution-spec
+description: Write or review a product specification for Agentic Tool Execution and Permission Boundary. Use when defining tool registration, JSON schema bounds, human-in-the-loop approvals, sandboxing, permission checks, audit logging, rate limits, or error recovery.
+---
+
+# Write an Agentic Tool Execution Specification
+
+Use application-native terms. Decide:
+- Who may execute which registered tools under which user role or tenant context
+- Required JSON schemas, argument types, required parameters, and unknown-field policy
+- Human-in-the-loop (HITL) approval rules for high-risk side-effecting operations
+- Execution sandboxing, CPU/memory resource limits, and network egress boundaries
+- Secret injection, token scope handling, and output credential redaction rules
+- Maximum execution timeouts, retry policies, and circuit breaker parameters
+- Audit log retention, trace metadata formatting, and observability rules
+
+Write scope, actors, objects, states, paths, user outcomes, permissions, validation, recovery, privacy, misuse, acceptance criteria, and unanswered decisions.


### PR DESCRIPTION
### Summary
Added a comprehensive, 100% MECE-compliant prebuilt workflow pack for **Agentic Tool Execution and Permission Boundary** under `prebuilt-workflow-paths/agentic-tool-execution-and-permission-boundary/`.

### What Was Included
- Complete 13-file structure (`README.md`, `PRODUCT_AND_BUSINESS_GUIDE.md`, `ENGINEERING_GUIDE.md`, `CORE_20_SCENARIOS.md`, `TESTING_GUIDE.md`, `PATHS_AND_EDGE_CASES.md`, `PERMISSION_AND_ABUSE_GUIDE.md`, `RETRY_AND_RECOVERY_GUIDE.md`, and 5 `*_SKILL.md` files with YAML frontmatter).
- Exactly 20 distinct core scenarios detailing triggers, boundaries, and explicit `Must not happen` outcomes.
- Comprehensive security controls for Indirect Prompt Injection, SSRF, Sandboxing, Human-in-the-loop (HITL) approval, and Secret Redaction.
- Indexed in `prebuilt-workflow-paths/README.md` and updated pack count to 19.

### Verification Performed
- Evaluated on `pallets/flask` using `unvibecode review` version `0.3.3`.
- Ran local quality test suite: `pytest` passed **652 / 652 tests**.
- Formatted and linted with `black` and `flake8`.