### PR TITLE
Fix README install command to match project docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Use UnvibeCode when you need to:
 ## Review your codebase in two commands
 
 ```bash
-pip install unvibecode
+python -m pip install --upgrade unvibecode
 python -m unvibecode review --repository "/path/to/repository"
 ```
 


### PR DESCRIPTION
README used pip install unvibecode, inconsistent with QUICKSTART.md, TROUBLESHOOTING.md, and CONTRIBUTING.md, which all use python -m pip install --upgrade unvibecode. This form avoids the "No module named unvibecode" issue documented in TROUBLESHOOTING.md when multiple Python environments are present. Verified locally: black, flake8, and full pytest suite (600 tests) pass unchanged.
Fixes #29 