### PR TITLE
docs: clarify shipready_results is UnvibeCode's expected report folder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ No activation key. No OpenAI API key. The repository path is the only required i
 
 UnvibeCode displays live progress, opens the completed reports, and saves the results automatically under `./shipready_results`.
 
+> **Note:** `shipready_results` is UnvibeCode's internal report-folder name — this is expected and not an error.
+
 ## One review. Four practical outputs.
 
 ### 1. Understand complex code connections

--- a/docs/OUTPUTS.md
+++ b/docs/OUTPUTS.md
@@ -66,6 +66,7 @@ If no candidate passes the evidence threshold, the report records a clear no-fin
 
 ## Results directory
 
+UnvibeCode's reports are generated under the `shipready_results/` folder — this is expected, not an error:
 ```text
 shipready_results/
 └── analysis_<timestamp>/

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -44,6 +44,8 @@ UnvibeCode displays live progress in the terminal. Completed HTML reports open a
 ./shipready_results/analysis_<timestamp>/customer_results/
 ```
 
+> `shipready_results` is UnvibeCode's internal report-folder name — this is expected and not an error.
+
 No activation key, customer OpenAI key, or `.env` file is required.
 
 ## Continue reading


### PR DESCRIPTION
## Problem
The output folder `./shipready_results/` and report headers use "SHIPREADY" branding, while the package is installed and documented everywhere else as `unvibecode`. This mismatch reads like an error to first-time users who just ran `pip install unvibecode` and see no confirmation that the output actually came from the tool they installed.

## Fix
Added a one-line clarifying note immediately after each place `shipready_results` first appears in README.md, docs/QUICKSTART.md, and docs/OUTPUTS.md, explaining that this is UnvibeCode's internal report-folder name and is expected behavior, not an error.

## Why this approach
No Python source for the CLI/reporting logic exists in this repo to rename directly, so this PR takes the documentation route suggested in the issue rather than a code-level rename.

Fixes #27