### PR TITLE
fix: replace legacy ShipReady output naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ python -m unvibecode review --repository "D:\upstox"
 
 No activation key. No OpenAI API key. The repository path is the only required input.
 
-UnvibeCode displays live progress, opens the completed reports, and saves the results automatically under `./shipready_results`.
+UnvibeCode displays live progress, opens the completed reports, and saves the results automatically under `./unvibecode_results`.
 
 ## One review. Four practical outputs.
 
@@ -131,7 +131,7 @@ Completed workflows are checked for failures that may affect customers, payments
 For a supported repository, the automatically created results folder contains:
 
 ```text
-shipready_results/
+unvibecode_results/
 `-- analysis_<timestamp>/
     `-- customer_results/
         |-- 01_connected_code_map_for_llm.html

--- a/docs/OUTPUTS.md
+++ b/docs/OUTPUTS.md
@@ -67,7 +67,7 @@ If no candidate passes the evidence threshold, the report records a clear no-fin
 ## Results directory
 
 ```text
-shipready_results/
+unvibecode_results/
 └── analysis_<timestamp>/
     └── customer_results/
         ├── 01_connected_code_map_for_llm.html

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -41,7 +41,7 @@ python3 -m unvibecode review --repository "/path/to/repository"
 UnvibeCode displays live progress in the terminal. Completed HTML reports open automatically and all customer files are saved under:
 
 ```text
-./shipready_results/analysis_<timestamp>/customer_results/
+./unvibecode_results/analysis_<timestamp>/customer_results/
 ```
 
 No activation key, customer OpenAI key, or `.env` file is required.


### PR DESCRIPTION
## Problem

The repository documentation still referenced the legacy `shipready_results` output directory even though the product is now named UnvibeCode.

## Changes

- Replaced `shipready_results/` with `unvibecode_results/` in `README.md`
- Updated the results directory in `docs/OUTPUTS.md`
- Updated the results path in `docs/QUICKSTART.md`

## Verification

- Searched the repository for the legacy `shipready_results` reference.
- Updated all documentation references found in the affected files.
- Changes were committed and pushed from `fix/shipready-branding`.

## Scope

Documentation-only branding/path consistency fix. No analyzer or runtime behaviour was changed.