### PR TITLE
Enforce that workflow-pack folder names carry no numeric prefix

### DIFF
--- a/.github/quality/tests/test_repository_quality.py
+++ b/.github/quality/tests/test_repository_quality.py
@@ -26,6 +26,7 @@ REQUIRED_PACK_FILES = {
 SKILL_FILES = {name for name in REQUIRED_PACK_FILES if name.endswith("_SKILL.md")}
 MARKDOWN_LINK = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
 CORE_SCENARIO_ROW = re.compile(r"^\|\s*(\d+)\s*\|", re.MULTILINE)
+NUMERIC_PREFIX = re.compile(r"^\d")
 
 
 def workflow_packs():
@@ -36,6 +37,11 @@ def workflow_packs():
 def test_workflow_pack_has_required_files(pack):
     present = {path.name for path in pack.iterdir() if path.is_file()}
     assert REQUIRED_PACK_FILES <= present, sorted(REQUIRED_PACK_FILES - present)
+
+
+@pytest.mark.parametrize("pack", workflow_packs(), ids=lambda path: path.name)
+def test_workflow_pack_folder_name_has_no_numeric_prefix(pack):
+    assert not NUMERIC_PREFIX.match(pack.name), f"{pack.name} starts with a digit"
 
 
 @pytest.mark.parametrize("pack", workflow_packs(), ids=lambda path: path.name)


### PR DESCRIPTION
The workflow-pack pull request checklist in CONTRIBUTING.md states: 'The folder name is descriptive and has no numeric prefix,' but no automated check verified the numeric-prefix half of that rule. A new pack folder named e.g. '01-order-placement' would still pass every existing test (required files, MECE boundary, 20 scenarios, skill frontmatter, index links).

Add test_workflow_pack_folder_name_has_no_numeric_prefix, parametrized across all workflow packs, asserting the folder name does not start with a digit.

'Descriptive' is left unchecked since that is a subjective judgment, not an objective, automatable rule; this keeps the check focused rather than attempting full semantic validation.

Verified against all 18 current packs (zero existing violations) and against a temporary pack folder named with a numeric prefix, which the test correctly failed. The temporary folder was removed before this commit; git status/diff show only the intended test-file change.

## Problem and scope

Describe the user problem and the focused scope of this change.

## What changed

Summarize the implementation or content change.

## Verification

List the commands, fixtures, public repositories, and outputs used to verify the change.

- [ ] `python -m black --config .github/quality/pyproject.toml --check .github/quality/tests`
- [ ] `python -m flake8 --config .github/quality/.flake8 .github/quality/tests`
- [ ] `python -m pytest -c .github/quality/pyproject.toml .github/quality/tests`
- [ ] I used UnvibeCode on a representative repository when the change affects code analysis, CLI behaviour, engineering guidance, or code-specific claims.
- [ ] I updated documentation for changed user-facing behaviour.
- [ ] I included no credentials, proprietary source, customer data, generated customer reports, or unsanitized logs.

## Workflow-pack checks

Complete these items only when adding or changing a pre-built workflow pack.

- [ ] The start, end, included scope, and excluded scope are explicit.
- [ ] The pack owns one primary business outcome and does not duplicate an existing pack.
- [ ] The 20 core scenarios are distinct and collectively cover the declared boundary.
- [ ] Every core scenario states what must not happen.
- [ ] All 13 required files use consistent `People and systems`, `Things created or changed`, `Stages`, and outcome names.

## Remaining limitations

List any known limitation or follow-up issue.
