### PR TITLE
[Improvement] Validate core scenario outcomes

### DIFF
--- a/.github/quality/tests/test_repository_quality.py
+++ b/.github/quality/tests/test_repository_quality.py
@@ -26,6 +26,9 @@ REQUIRED_PACK_FILES = {
 SKILL_FILES = {name for name in REQUIRED_PACK_FILES if name.endswith("_SKILL.md")}
 MARKDOWN_LINK = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
 CORE_SCENARIO_ROW = re.compile(r"^\|\s*(\d+)\s*\|", re.MULTILINE)
+CORE_SCENARIO_WITH_OUTCOME = re.compile(
+    r"^\|\s*(\d+)\s*\|[^|]+\|\s*\S[^|]*\|\s*$", re.MULTILINE
+)
 
 
 def workflow_packs():
@@ -52,6 +55,15 @@ def test_workflow_pack_has_exactly_twenty_core_scenarios(pack):
     content = (pack / "CORE_20_SCENARIOS.md").read_text(encoding="utf-8")
     scenario_numbers = [int(value) for value in CORE_SCENARIO_ROW.findall(content)]
     assert scenario_numbers == list(range(1, 21))
+
+
+@pytest.mark.parametrize("pack", workflow_packs(), ids=lambda path: path.name)
+def test_every_core_scenario_states_an_outcome_to_prevent(pack):
+    content = (pack / "CORE_20_SCENARIOS.md").read_text(encoding="utf-8")
+    scenarios_with_outcomes = [
+        int(value) for value in CORE_SCENARIO_WITH_OUTCOME.findall(content)
+    ]
+    assert scenarios_with_outcomes == list(range(1, 21))
 
 
 @pytest.mark.parametrize("pack", workflow_packs(), ids=lambda path: path.name)


### PR DESCRIPTION
## Problem and scope

Workflow packs promise that every core scenario states what must not happen, but the existing quality suite only checked that rows 1 through 20 existed. A scenario could therefore have an empty prevention outcome without failing validation.

## What changed

Added a Markdown-table validation that requires every numbered row in each CORE_20_SCENARIOS.md file to include a non-empty prevention outcome.

## Verification

- python -m black --config .github/quality/pyproject.toml --check .github/quality/tests
- python -m flake8 --config .github/quality/.flake8 .github/quality/tests
- python -m pytest -c .github/quality/pyproject.toml .github/quality/tests (616 passed)
- This is repository-quality validation only; it does not change code analysis, CLI behaviour, or code-specific claims, so an UnvibeCode review was not required.

## Remaining limitations

The check verifies that an outcome is present, not whether its wording is semantically complete.