### PR TITLE
[Improvement] Add concrete API test example for payment idempotency scenario

### DIFF
--- a/prebuilt-workflow-paths/checkout-payment-authorization-and-capture/TESTING_GUIDE.md
+++ b/prebuilt-workflow-paths/checkout-payment-authorization-and-capture/TESTING_GUIDE.md
@@ -146,6 +146,21 @@ Check authoritative records, financial or inventory changes, permissions, extern
 
 **Best test levels:** Security and integration.
 
+**Example API Test (Python/pytest):**
+```python
+def test_idempotency_rejects_changed_payload(api_client):
+    # Given: An attempt successfully processed with key K and amount 100
+    idempotency_key = "req_8f7b2c9a"
+    res1 = api_client.post("/charge", json={"amount": 100}, headers={"Idempotency-Key": idempotency_key})
+    assert res1.status_code == 200
+
+    # When: A new request arrives with the same key K but amount 500
+    res2 = api_client.post("/charge", json={"amount": 500}, headers={"Idempotency-Key": idempotency_key})
+
+    # Expect: The request is safely rejected to prevent the old key from authorizing a different payment
+    assert res2.status_code == 409
+    assert "idempotency_mismatch" in res2.json()["error"]["code"]
+```
 ## 13. Payment attempts are flooded
 
 **Given:** One source makes repeated payment or card-verification attempts


### PR DESCRIPTION
## Problem and scope

The `checkout-payment-authorization-and-capture` testing guide defines excellent abstract scenarios (Given/When/Expect), but engineers often struggle to translate distributed systems failures (like idempotency mismatches) into concrete API tests.

This PR adds one useful, concrete `pytest` example to Scenario 12 ("Idempotency key is replayed with changed payload") to bridge the gap between the business rule and the actual engineering implementation.

## What changed

Added a concrete Python/pytest code block to `TESTING_GUIDE.md` under Scenario 12 showing exactly how to assert HTTP 409 Conflicts when a payload changes under the same idempotency key.

## Verification

- [x] `python -m black --config .github/quality/pyproject.toml --check .github/quality/tests`
- [x] `python -m flake8 --config .github/quality/.flake8 .github/quality/tests`
- [x] `python -m pytest -c .github/quality/pyproject.toml .github/quality/tests`
- [x] I used UnvibeCode on a representative repository when the change affects code analysis, CLI behaviour, engineering guidance, or code-specific claims.
- [x] I updated documentation for changed user-facing behaviour.
- [x] I included no credentials, proprietary source, customer data, generated customer reports, or unsanitized logs.

## Remaining limitations

None. This pattern could eventually be extended to other complex scenarios like "15. Provider times out uncertainly".