### PR TITLE
[Improvement] Enforce non-empty Must Not Happen column in core scenarios

### DIFF
--- a/.github/quality/tests/test_repository_quality.py
+++ b/.github/quality/tests/test_repository_quality.py
@@ -26,7 +26,9 @@ REQUIRED_PACK_FILES = {
 SKILL_FILES = {name for name in REQUIRED_PACK_FILES if name.endswith("_SKILL.md")}
 MARKDOWN_LINK = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
 CORE_SCENARIO_ROW = re.compile(r"^\|\s*(\d+)\s*\|", re.MULTILINE)
-CORE_SCENARIO_MUST_NOT = re.compile(r"^\|\s*\d+\s*\|[^|]+\|\s*(\S[^|]*?)\s*\|", re.MULTILINE)
+CORE_SCENARIO_MUST_NOT = re.compile(
+    r"^\|\s*\d+\s*\|[^|]+\|\s*(\S[^|]*?)\s*\|", re.MULTILINE
+)
 
 
 def workflow_packs():
@@ -59,7 +61,9 @@ def test_workflow_pack_has_exactly_twenty_core_scenarios(pack):
 def test_core_scenarios_must_not_happen_column_is_populated(pack):
     content = (pack / "CORE_20_SCENARIOS.md").read_text(encoding="utf-8")
     constraints = CORE_SCENARIO_MUST_NOT.findall(content)
-    assert len(constraints) == 20, f"Expected 20 'Must not happen' entries, found {len(constraints)}"
+    assert (
+        len(constraints) == 20
+    ), f"Expected 20 'Must not happen' entries, found {len(constraints)}"
 
 
 @pytest.mark.parametrize("pack", workflow_packs(), ids=lambda path: path.name)

--- a/.github/quality/tests/test_repository_quality.py
+++ b/.github/quality/tests/test_repository_quality.py
@@ -26,6 +26,7 @@ REQUIRED_PACK_FILES = {
 SKILL_FILES = {name for name in REQUIRED_PACK_FILES if name.endswith("_SKILL.md")}
 MARKDOWN_LINK = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
 CORE_SCENARIO_ROW = re.compile(r"^\|\s*(\d+)\s*\|", re.MULTILINE)
+CORE_SCENARIO_MUST_NOT = re.compile(r"^\|\s*\d+\s*\|[^|]+\|\s*(\S[^|]*?)\s*\|", re.MULTILINE)
 
 
 def workflow_packs():
@@ -52,6 +53,13 @@ def test_workflow_pack_has_exactly_twenty_core_scenarios(pack):
     content = (pack / "CORE_20_SCENARIOS.md").read_text(encoding="utf-8")
     scenario_numbers = [int(value) for value in CORE_SCENARIO_ROW.findall(content)]
     assert scenario_numbers == list(range(1, 21))
+
+
+@pytest.mark.parametrize("pack", workflow_packs(), ids=lambda path: path.name)
+def test_core_scenarios_must_not_happen_column_is_populated(pack):
+    content = (pack / "CORE_20_SCENARIOS.md").read_text(encoding="utf-8")
+    constraints = CORE_SCENARIO_MUST_NOT.findall(content)
+    assert len(constraints) == 20, f"Expected 20 'Must not happen' entries, found {len(constraints)}"
 
 
 @pytest.mark.parametrize("pack", workflow_packs(), ids=lambda path: path.name)


### PR DESCRIPTION
## Problem and scope

The PR template explicitly requires that `Every core scenario states what must not happen.` However, the existing `test_workflow_pack_has_exactly_twenty_core_scenarios` test only checks that row numbers 1–20 exist—it does not verify that the constraint column is actually populated.

This means a future contributor could submit 20 core scenarios with completely empty `Must not happen` cells, and the CI test would pass, silently violating the project's own structural requirement.

## What changed

Added `test_core_scenarios_must_not_happen_column_is_populated` to `test_repository_quality.py`.

This test extracts the third pipe-delimited column from each numbered row in `CORE_20_SCENARIOS.md` and asserts that exactly 20 non-empty constraint entries exist. It uses a new `CORE_SCENARIO_MUST_NOT` regex that matches the existing pattern used by `CORE_SCENARIO_ROW`.

## Verification

- [x] `python -m black --config .github/quality/pyproject.toml --check .github/quality/tests`
- [x] `python -m flake8 --config .github/quality/.flake8 .github/quality/tests`
- [x] `python -m pytest -c .github/quality/pyproject.toml .github/quality/tests`
- [x] I used UnvibeCode on a representative repository when the change affects code analysis, CLI behaviour, engineering guidance, or code-specific claims.
- [x] I updated documentation for changed user-facing behaviour.
- [x] I included no credentials, proprietary source, customer data, generated customer reports, or unsanitized logs.

(All 18 existing workflow packs passed the new constraint verification).

## Remaining limitations

This test validates that the constraint column contains non-whitespace characters, but cannot validate semantic meaning. Semantic validation still requires human review.