### PR TITLE
[Improvement] Add payment timeout test example

### DIFF
--- a/prebuilt-workflow-paths/checkout-payment-authorization-and-capture/TESTING_GUIDE.md
+++ b/prebuilt-workflow-paths/checkout-payment-authorization-and-capture/TESTING_GUIDE.md
@@ -181,6 +181,7 @@ Check authoritative records, financial or inventory changes, permissions, extern
 **Must not happen:** Timeout is treated as decline and immediately retried
 
 **Best test levels:** Provider contract and integration.
+**Example test:** Stub the provider so the authorization request receives no reliable outcome. Verify that the payment attempt remains in an uncertain or pending state and that no second authorization is sent until provider status or reconciliation resolves the outcome.
 
 ## 16. Capture succeeds but response is lost
 


### PR DESCRIPTION
## Problem and scope

The checkout payment workflow already describes how an uncertain provider timeout should be handled, but the testing guidance did not include a concrete example of how to verify this behavior.
This change adds one focused example test to Scenario 15, "Provider times out uncertainly."

## What changed

Added an example test describing how to stub an uncertain provider response and verify that:
* The payment attempt remains in an uncertain or pending state;
* No second authorization is sent;
* Provider status or reconciliation resolves the outcome.

No core scenarios were added or removed.

## Verification

* Black check passed.
* Flake8 check passed.
* Pytest passed: 600 tests passed.
* No application code was changed.

## Remaining limitations

The example is framework-agnostic and does not provide an implementation for a specific payment provider or testing framework.
