### PR TITLE
[Improvement] Document tiktoken blob 403 troubleshooting

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -52,3 +52,49 @@ The terminal prints the customer-facing reason and the technical-log location. P
 
 When opening an issue, remove source code, credentials, customer information, and other sensitive data from logs.
 
+## "403 Client Error: Forbidden" fetching `cl100k_base.tiktoken`
+
+**Symptom**
+
+The `Business Workflow & Risk Review` stage stalls or reports "needs attention"
+with an error similar to:
+
+```
+403 Client Error: Forbidden for url: https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken
+```
+
+The `Connected Code Map for LLMs` stage still completes normally, since it
+runs entirely locally.
+
+**Cause**
+
+UnvibeCode uses the `tiktoken` library to estimate token counts before
+sending context to the hosted review service. On first use, `tiktoken`
+downloads its encoding file from
+`openaipublic.blob.core.windows.net`. Corporate proxies, VPNs, and locked-down
+CI/sandbox networks commonly block this domain even when the main UnvibeCode
+API host is reachable, which surfaces as a 403 instead of a clearer
+network-configuration message.
+
+**Fix**
+
+1. Confirm your network allowlist includes `openaipublic.blob.core.windows.net`
+   in addition to UnvibeCode's own API host, then re-run the review.
+2. If you can't allowlist that domain, pre-download the encoding file once
+   from a machine that has access, then point `tiktoken` at a local cache
+   directory:
+
+   ```bash
+   export TIKTOKEN_CACHE_DIR=/path/to/cache
+   ```
+
+   Copy the cached file from the working machine's cache directory (same env
+   var) into that path before running `unvibecode review` on the restricted
+   network.
+3. Re-run `python -m unvibecode review --repository "/path/to/repository"`.
+   The Connected Code Map and Complete Repository Context outputs from the
+   earlier run are unaffected and do not need to be regenerated.
+
+If the error persists after allowlisting or caching, open a GitHub issue with
+your OS, Python version, and the full `technical_logs/business_workflow_review.log`
+output (with any repository-specific paths redacted).


### PR DESCRIPTION
## Problem and scope

Running `python -m unvibecode review` on a network with a restrictive
egress allowlist (corporate proxy, VPN, or locked-down CI/sandbox) causes
the Business Workflow & Risk Review stage to fail with an opaque
`403 Client Error: Forbidden` for `openaipublic.blob.core.windows.net`,
with no indication of what that domain is or how to fix it. The
Connected Code Map stage completes fine since it runs locally, so the
error is easy to misread as a partial UnvibeCode outage rather than a
network-config issue.

Scope: documentation only. Adds one troubleshooting entry to
`docs/TROUBLESHOOTING.md`. No code, CLI behavior, or analysis logic is
changed.

## What changed

Added a `### "403 Client Error" fetching cl100k_base.tiktoken` section to
`docs/TROUBLESHOOTING.md` covering:
- The exact symptom/error text so it's searchable
- Root cause: `tiktoken` (UnvibeCode's token-counting dependency) fetches
  its encoding file from `openaipublic.blob.core.windows.net` on first
  use, separately from UnvibeCode's own API host
- Fix 1: allowlist that domain alongside UnvibeCode's API host
- Fix 2: pre-cache the encoding file via `TIKTOKEN_CACHE_DIR` for
  networks where the domain can't be allowlisted
- A pointer to open an issue with `technical_logs/business_workflow_review.log`
  if the error persists after either fix

## Verification

- Ran `pip install unvibecode` and `python -m unvibecode review --repository`
  against the public [pallets/flask](https://github.com/pallets/flask)
  repository (105 source files) in a sandboxed environment with a
  restricted domain allowlist.
- Reproduced the exact `403 Client Error ... cl100k_base.tiktoken` error
  during the Business Workflow & Risk Review stage; confirmed the
  Connected Code Map stage still completed 100% in the same run.
- Traced the root cause by inspecting the installed `tiktoken` package
  source (`tiktoken/load.py`, `read_file_cached`), confirming it reads
  `TIKTOKEN_CACHE_DIR` / `DATA_GYM_CACHE_DIR` before falling back to a
  temp-dir cache, which is what the second fix relies on.
- Previewed the rendered Markdown locally to check formatting.

- [ ] `python -m black --config .github/quality/pyproject.toml --check .github/quality/tests` — N/A, no Python files changed
- [ ] `python -m flake8 --config .github/quality/.flake8 .github/quality/tests` — N/A, no Python files changed
- [ ] `python -m pytest -c .github/quality/pyproject.toml .github/quality/tests` — N/A, no Python files changed
- [x] I used UnvibeCode on a representative repository when the change affects code analysis, CLI behaviour, engineering guidance, or code-specific claims.
- [x] I updated documentation for changed user-facing behaviour.
- [x] I included no credentials, proprietary source, customer data, generated customer reports, or unsanitized logs.

## Workflow-pack checks

N/A — this change does not add or modify a pre-built workflow pack.

## Remaining limitations

- The fix assumes the user has some machine with unrestricted network
  access to pre-populate the `tiktoken` cache; environments with zero
  outbound access anywhere would need a different solution (e.g. bundling
  the encoding file), which is out of scope for this doc-only PR.
- I haven't confirmed whether UnvibeCode's hosted API host itself is ever
  blocked by the same class of proxy, only the separate `tiktoken` blob
  domain — worth a follow-up issue if that turns out to be common too.