### PR TITLE
[Improvement] Document blocked cl100k_base encoding download in TROUBLESHOOTING

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -42,9 +42,41 @@ python3 -m unvibecode review --repository "/Users/example/My Repository"
 
 Confirm that the computer has internet access and that organizational firewall rules allow HTTPS access to the hosted UnvibeCode service.
 
+## A review stops with a `cl100k_base.tiktoken` error
+
+The Business Workflow and Risk Review budgets its inputs with the `cl100k_base` token encoding. The first run downloads that encoding file from `openaipublic.blob.core.windows.net`. No OpenAI API key is required, but the host has to be reachable.
+
+When a firewall or proxy blocks the host, the review stops and the terminal reports a reason similar to:
+
+```text
+403 Client Error: Forbidden for url: https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken
+```
+
+An unreachable proxy reports a `ProxyError` for the same URL. In both cases the Connected Code Map and Complete Repository Context are still produced.
+
+Allow HTTPS access to `openaipublic.blob.core.windows.net` and run the review again.
+
+For a machine that cannot reach the host, prepare the encoding cache once on a connected machine and copy the directory across. Set the cache directory, run any review to populate it, then copy the directory to the restricted machine and set the same variable there.
+
+Windows:
+
+```powershell
+$env:TIKTOKEN_CACHE_DIR = "C:\unvibecode-tiktoken-cache"
+python -m unvibecode review --repository "D:\flask"
+```
+
+macOS or Linux:
+
+```bash
+export TIKTOKEN_CACHE_DIR="$HOME/unvibecode-tiktoken-cache"
+python3 -m unvibecode review --repository "/path/to/repository"
+```
+
 ## Only the Connected Code Map was produced
 
 Repositories above approximately two million estimated source tokens intentionally receive the Connected Code Map and Complete Repository Context without the deeper Business Workflow and Risk Review.
+
+A smaller repository that produces only the Connected Code Map has failed rather than been skipped. Read the printed reason and `technical_logs/business_workflow_review.log` inside the analysis folder. A blocked `cl100k_base.tiktoken` download is one known cause.
 
 ## A review needs attention
 


### PR DESCRIPTION
## Problem and scope

The Business Workflow and Risk Review fails on a reachable, correctly-sized repository when `openaipublic.blob.core.windows.net` is blocked. The stage builds a token budget with the `cl100k_base` encoding, which tiktoken downloads on first use. No OpenAI API key is involved, so users on corporate proxies or restricted networks have no obvious reason to suspect a network dependency, and `docs/TROUBLESHOOTING.md` does not name the host.

The existing section "Only the Connected Code Map was produced" makes this harder to diagnose: it attributes that symptom to repositories above approximately two million estimated source tokens. I reproduced the same symptom on Flask at 188,011 estimated tokens, where the cause was the blocked download rather than the size threshold.

Scope is documentation only.

## What changed

`docs/TROUBLESHOOTING.md`:

- New section describing the failure, naming the exact host to allow, and showing the `TIKTOKEN_CACHE_DIR` approach for machines that cannot reach it.
- The "Only the Connected Code Map was produced" section now distinguishes the intentional size threshold from a failed review, and points to `technical_logs/business_workflow_review.log`.

## Verification

- UnvibeCode version: `0.3.3`
- Platform: Windows 11, Python 3.13.0
- Test repository: `pallets/flask` (public), Python, 188,011 estimated tokens across 105 source files
- Output reviewed: terminal progress output and `technical_logs/business_workflow_review.log`

With the host reachable, the review completed and produced the Connected Code Map, Business Workflow Map, and Business Risk Findings.

Reproduced the failure with an empty encoding cache and an unreachable proxy:

```powershell
$env:TIKTOKEN_CACHE_DIR = "C:\empty-tk"
$env:HTTPS_PROXY = "http://127.0.0.1:9"
python -m unvibecode review --repository "D:\flask"
```

Result: exit code 1. The Connected Code Map reached 100%, and the Business Workflow and Risk Review stopped at stage 2 of 6 reporting:

```text
requests.exceptions.ProxyError: HTTPSConnectionPool(host='openaipublic.blob.core.windows.net', port=443):
Max retries exceeded with url: /encodings/cl100k_base.tiktoken
```

The log shows the call originating from `TokenCounter.__init__` in `02_shipreadyv2_prepare_pass1_inputs.py`, which reaches `tiktoken.get_encoding("cl100k_base")`.

- [x] `python -m black --config .github/quality/pyproject.toml --check .github/quality/tests` — clean
- [x] `python -m flake8 --config .github/quality/.flake8 .github/quality/tests` — clean
- [x] `python -m pytest -c .github/quality/pyproject.toml .github/quality/tests` — 596 passed
- [x] I used UnvibeCode on a representative repository
- [x] I updated documentation for changed user-facing behaviour
- [x] No credentials, proprietary source, customer data, or unsanitized logs included

## Remaining limitations

This documents the failure rather than removing it. Two engine modules already degrade gracefully when the encoding is unavailable, falling back to a character-based estimate, while the modules on the review path surface the error instead. Making that handling consistent would remove the need for this section, but the analyzer source is not part of this repository. Happy to open a separate issue for that if useful.