### PR TITLE
[Improvement] Validate testing guide scenario synchronization

### DIFF
--- a/.github/quality/tests/test_repository_quality.py
+++ b/.github/quality/tests/test_repository_quality.py
@@ -26,6 +26,8 @@ REQUIRED_PACK_FILES = {
 SKILL_FILES = {name for name in REQUIRED_PACK_FILES if name.endswith("_SKILL.md")}
 MARKDOWN_LINK = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
 CORE_SCENARIO_ROW = re.compile(r"^\|\s*(\d+)\s*\|", re.MULTILINE)
+CORE_SCENARIO_TITLE = re.compile(r"^\|\s*(\d+)\s*\|\s*([^|]+?)\s*\|", re.MULTILINE)
+TESTING_GUIDE_HEADING = re.compile(r"^##\s*(\d+)\.\s*(.+?)\s*$", re.MULTILINE)
 
 
 def workflow_packs():
@@ -52,6 +54,47 @@ def test_workflow_pack_has_exactly_twenty_core_scenarios(pack):
     content = (pack / "CORE_20_SCENARIOS.md").read_text(encoding="utf-8")
     scenario_numbers = [int(value) for value in CORE_SCENARIO_ROW.findall(content)]
     assert scenario_numbers == list(range(1, 21))
+
+
+@pytest.mark.parametrize("pack", workflow_packs(), ids=lambda path: path.name)
+def test_testing_guide_scenarios_match_core_scenarios(pack):
+    core_content = (pack / "CORE_20_SCENARIOS.md").read_text(encoding="utf-8")
+    testing_content = (pack / "TESTING_GUIDE.md").read_text(encoding="utf-8")
+
+    core_scenarios = [
+        (int(num), title.strip())
+        for num, title in CORE_SCENARIO_TITLE.findall(core_content)
+    ]
+    testing_scenarios = [
+        (int(num), title.strip())
+        for num, title in TESTING_GUIDE_HEADING.findall(testing_content)
+    ]
+
+    assert (
+        len(core_scenarios) == 20
+    ), "CORE_20_SCENARIOS.md does not have exactly 20 valid titles"
+    assert (
+        len(testing_scenarios) == 20
+    ), "TESTING_GUIDE.md does not have exactly 20 scenario headings"
+
+    expected_sequence = list(range(1, 21))
+    assert [
+        num for num, _ in core_scenarios
+    ] == expected_sequence, "Core scenarios are not exactly numbered 1 to 20 in order"
+    assert [
+        num for num, _ in testing_scenarios
+    ] == expected_sequence, (
+        "Testing scenarios are not exactly numbered 1 to 20 in order"
+    )
+
+    for i in range(20):
+        core_title = core_scenarios[i][1]
+        testing_title = testing_scenarios[i][1]
+        assert core_title == testing_title, (
+            f"Testing Guide scenario {i+1} title does not match CORE_20_SCENARIOS.md.\n"
+            f"Expected: '{core_title}'\n"
+            f"Found: '{testing_title}'"
+        )
 
 
 @pytest.mark.parametrize("pack", workflow_packs(), ids=lambda path: path.name)


### PR DESCRIPTION
## Problem and scope

`CORE_20_SCENARIOS.md` and `TESTING_GUIDE.md` represent the same 20 scenarios.

The existing quality suite validates the presence and order of the 20 core scenarios but did not verify that the detailed testing guide remains synchronized with the core scenario titles. A contributor could rename, reorder, remove, or duplicate a scenario in one file and leave the other inconsistent without the quality suite detecting the drift.

The scope of this change is strictly limited to the test suite (`.github/quality/tests/test_repository_quality.py`).

## What changed

Added `test_testing_guide_scenarios_match_core_scenarios`.

The test:

- extracts the numbered scenario titles from `CORE_20_SCENARIOS.md`
- extracts the numbered scenario headings from `TESTING_GUIDE.md`
- verifies both contain exactly 20 scenarios
- verifies numbering is exactly 1–20 in order
- verifies the scenario titles match position-by-position

*Implementation Note:* The test utilizes the repository's existing Markdown structured parsing format and `pytest` parametrization over the workflow packs.

## Verification

The following verification steps were performed locally:

- Targeted synchronization test: 18 passed
- Deliberate `Scenario 12` title mutation in a local workflow pack: Correctly failed
- Restored targeted test: 18 passed
- `python -m py_compile .github/quality/tests/test_repository_quality.py`: Passed
- `git diff --check`: Passed

- [ ] `python -m black --config .github/quality/pyproject.toml --check .github/quality/tests` (Passed)
- [ ] `python -m flake8 --config .github/quality/.flake8 .github/quality/tests` (Passed)
- [x] `python -m pytest -c .github/quality/pyproject.toml .github/quality/tests` (616 passed)
- [x] I used UnvibeCode on a representative repository when the change affects code analysis, CLI behaviour, engineering guidance, or code-specific claims.
- [x] I updated documentation for changed user-facing behaviour.
- [x] I included no credentials, proprietary source, customer data, generated customer reports, or unsanitized logs.

## Workflow-pack checks

Complete these items only when adding or changing a pre-built workflow pack.

- [ ] The start, end, included scope, and excluded scope are explicit.
- [ ] The pack owns one primary business outcome and does not duplicate an existing pack.
- [ ] The 20 core scenarios are distinct and collectively cover the declared boundary.
- [ ] Every core scenario states what must not happen.
- [ ] All 13 required files use consistent `People and systems`, `Things created or changed`, `Stages`, and outcome names.

## Remaining limitations

The test validates scenario count, numbering, ordering, and title synchronization between `CORE_20_SCENARIOS.md` and `TESTING_GUIDE.md`. It does not validate semantic equivalence of the scenario content itself.