### PR TITLE
[Improvement] Clarify review coverage for evidence-based conclusions

### DIFF
--- a/AI Engineering Cheatsheet/AI_CODING_DESIGN_AND_ARCHITECTURE_PRINCIPLES.md
+++ b/AI Engineering Cheatsheet/AI_CODING_DESIGN_AND_ARCHITECTURE_PRINCIPLES.md
@@ -155,10 +155,11 @@ flowchart TD
 - Ask for missing files or runtime evidence instead of inventing behaviour.
 - Show conflicting evidence rather than silently choosing the most convenient interpretation.
 - Re-check evidence after edits because line numbers, dependencies, and behaviour may have changed.
+- State the review coverage and evidence boundaries alongside conclusions; never present a partial analysis as a repository-wide guarantee.
 
 **Avoid:** Reporting a vulnerability, architecture, or completed fix based only on filenames, conventions, or plausible model reasoning.
 
-**Architecture check:** Can a reviewer independently reproduce every high-impact conclusion from the cited repository or runtime evidence?
+**Architecture check:** Can a reviewer independently reproduce every high-impact conclusion from the cited repository or runtime evidence, and can they tell exactly what was and was not reviewed?
 
 ---
 


### PR DESCRIPTION
## Problem and scope

Repository analysis conclusions can be misinterpreted when the review covers only part of the available repository evidence. A "no findings" result should not be treated as a repository-wide guarantee when the analysis has incomplete coverage.

## What changed

Updated the "Evidence Before Assertion" principle to explicitly require review coverage and evidence boundaries to be stated alongside conclusions.

Also updated the architecture check so reviewers can determine what was and was not reviewed.

## Verification

* Reviewed the existing Evidence Before Assertion guidance.
* Based the clarification on an actual UnvibeCode repository review where the Business Risk Review reported no evidence-supported findings while noting that only 1 of 2 review areas was completed.
* Confirmed that the change is limited to the AI Coding Design and Architecture Principles cheatsheet.
* No application code or runtime behavior was changed.
