### PR TITLE
[Improvement] Improve hosted analysis troubleshooting guidance

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -50,5 +50,15 @@ Repositories above approximately two million estimated source tokens intentional
 
 The terminal prints the customer-facing reason and the technical-log location. Preserve the analysis folder when reporting a reproducible problem.
 
-When opening an issue, remove source code, credentials, customer information, and other sensitive data from logs.
+If some customer results were produced successfully, check the `customer_results` directory before reporting the failure. A partial review can still provide useful outputs even when the deeper Business Workflow and Risk Review needs attention.
 
+For a reproducible hosted-analysis failure:
+
+1. Record the UnvibeCode version with `python -m unvibecode --version`.
+2. Record the repository size shown by the review command.
+3. Note which customer results were produced successfully.
+4. Open the referenced technical log and record the final error message.
+5. Confirm that the repository path is correct and that the computer can reach the internet, then retry the review.
+6. If the same failure occurs, preserve the analysis folder and include the sanitized error details when reporting the problem.
+
+Do not upload generated reports containing source code, credentials, customer information, or other sensitive data.


### PR DESCRIPTION
## Problem and scope

When a hosted analysis fails after producing partial customer results, the existing troubleshooting guidance only says to preserve the analysis folder and report the sanitized error.

This does not give users a concrete way to investigate a reproducible hosted-analysis failure or distinguish between a complete failure and a partial review where useful customer results were already produced.

This change is focused on improving the troubleshooting guidance for hosted-analysis failures.

## What changed

Updated `docs/TROUBLESHOOTING.md` to:

- Tell users to inspect the `customer_results` directory when a review needs attention.
- Explain that partial customer results may still be useful.
- Provide a step-by-step diagnostic process for reproducible hosted-analysis failures.
- Tell users to record the UnvibeCode version and repository size.
- Tell users to identify which customer results were successfully produced.
- Tell users to inspect the referenced technical log and record the final error.
- Tell users to verify the repository path and internet connectivity before retrying.
- Explain when to preserve the analysis folder for reporting.
- Reinforce that generated reports, credentials, customer information, and source code must not be uploaded.

## Verification

The following local quality checks passed:

- `git diff --check`
- `python -m black --config .github/quality/pyproject.toml --check .github/quality/tests`
- `python -m flake8 --config .github/quality/.flake8 .github/quality/tests`
- `python -m pytest -c .github/quality/pyproject.toml .github/quality/tests`

Result:

`598 passed`

I also reproduced a hosted-analysis failure while reviewing the public Flask repository and used the resulting customer output directory and technical log to identify the information that a user needs when reporting a reproducible failure.

No credentials, proprietary source code, customer data, or generated customer reports are included in this contribution.

## Remaining limitations

This change improves troubleshooting guidance but does not change the hosted-analysis retry or connection behaviour itself.

It also does not attempt to diagnose the underlying hosted service failure automatically.

Closes #57
