### PR TITLE
docs: add contributor checklist for documentation changes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,6 +20,16 @@ Contributions are welcome from Python developers, static-analysis enthusiasts, p
 
 Keep proprietary repositories, credentials, customer data, generated customer reports, and unsanitized logs out of commits, issues, and pull requests.
 
+## Documentation-only changes
+
+Before opening a pull request for documentation changes:
+
+- Check Markdown formatting.
+- Confirm that all referenced file paths exist.
+- Verify that examples match the current project structure.
+- Run the relevant documentation and quality checks.
+- Make sure no credentials, proprietary data, or unsanitized logs are included.
+
 ## Local quality setup
 
 This public repository currently contains documentation, workflow packs, and their validation tests. Create and activate a Python 3.11-or-newer virtual environment from the repository root:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ python -m unvibecode review --repository "D:\upstox"
 
 No activation key. No OpenAI API key. The repository path is the only required input.
 
-UnvibeCode displays live progress, opens the completed reports, and saves the results automatically under `./shipready_results`.
+UnvibeCode displays live progress, opens the completed reports, and saves the results automatically under `./unvibecode_results`.
 
 ## One review. Four practical outputs.
 
@@ -131,7 +131,7 @@ Completed workflows are checked for failures that may affect customers, payments
 For a supported repository, the automatically created results folder contains:
 
 ```text
-shipready_results/
+unvibecode_results/
 `-- analysis_<timestamp>/
     `-- customer_results/
         |-- 01_connected_code_map_for_llm.html

--- a/docs/OUTPUTS.md
+++ b/docs/OUTPUTS.md
@@ -67,7 +67,7 @@ If no candidate passes the evidence threshold, the report records a clear no-fin
 ## Results directory
 
 ```text
-shipready_results/
+unvibecode_results/
 └── analysis_<timestamp>/
     └── customer_results/
         ├── 01_connected_code_map_for_llm.html

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -41,7 +41,7 @@ python3 -m unvibecode review --repository "/path/to/repository"
 UnvibeCode displays live progress in the terminal. Completed HTML reports open automatically and all customer files are saved under:
 
 ```text
-./shipready_results/analysis_<timestamp>/customer_results/
+./unvibecode_results/analysis_<timestamp>/customer_results/
 ```
 
 No activation key, customer OpenAI key, or `.env` file is required.


### PR DESCRIPTION
## Problem and scope

Documentation-only contributors do not have a dedicated checklist before opening a pull request, making it easier to overlook basic validation steps.

## What changed

- Added a new **Documentation-only changes** section to `.github/CONTRIBUTING.md`.
- Included a short checklist reminding contributors to:
  - Check Markdown formatting.
  - Confirm referenced file paths exist.
  - Verify examples match the current project structure.
  - Run documentation and quality checks.
  - Ensure no credentials, proprietary data, or unsanitized logs are included.

## Verification

- Documentation reviewed for formatting and consistency.
- Verified Markdown renders correctly.
- No code or workflow logic was changed.

- [x] I updated documentation for changed user-facing behaviour.
- [x] I included no credentials, proprietary source, customer data, generated customer reports, or unsanitized logs.

## Remaining limitations

None.