### PR TITLE
[Improvement] Add OAuth authorization and account linking workflow pack

### DIFF
--- a/prebuilt-workflow-paths/README.md
+++ b/prebuilt-workflow-paths/README.md
@@ -54,6 +54,12 @@ No installation, generator, schema, or build step is required. Every workflow is
 | [Seller or Service-provider Onboarding and Eligibility](seller-and-service-provider-onboarding/) | verifies and activates providers before allowing them to sell or deliver services |
 | [Commission, Fee, Split Payout, and Seller Settlement](marketplace-fees-split-payouts-and-settlement/) | calculates platform fees and settles funds among sellers or service providers |
 
+### Identity, access, and integrations
+
+| Workflow | Use it when your application… |
+|---|---|
+| [OAuth Authorization and Account Linking](oauth-authorization-and-account-linking/) | signs users in through an external provider or links an external identity or data-provider account to a local account |
+
 ### LLM, retrieval, and external systems
 
 | Workflow | Use it when your application… |
@@ -129,10 +135,10 @@ Read the [repository contribution guide](../.github/CONTRIBUTING.md) before prop
 
 ## Collection summary
 
-- 18 independently usable business workflow packs
-- 234 workflow-specific Markdown files
-- 360 compact core scenarios
-- 360 complete Given/When/Expect scenario descriptions
-- 90 portable task skills
+- 19 independently usable business workflow packs
+- 247 workflow-specific Markdown files
+- 380 compact core scenarios
+- 380 complete Given/When/Expect scenario descriptions
+- 95 portable task skills
 
 These packs are starting points for application-specific analysis. Product rules, laws, provider contracts, data-retention requirements, and operational limits still need to be adapted to the repository being reviewed.

--- a/prebuilt-workflow-paths/oauth-authorization-and-account-linking/CORE_20_SCENARIOS.md
+++ b/prebuilt-workflow-paths/oauth-authorization-and-account-linking/CORE_20_SCENARIOS.md
@@ -1,0 +1,26 @@
+# Core 20 Scenarios
+
+| # | Scenario | Must not happen |
+|---:|---|---|
+| 1 | Eligible user links a provider account once | One provider account creates duplicate local links |
+| 2 | Returning user signs in with the linked provider | The provider subject maps to the wrong local account |
+| 3 | State or PKCE verifier is missing or wrong | The callback still creates a session or link |
+| 4 | Provider denies consent | Denial is stored as a successful connection |
+| 5 | Callback code is replayed | A second session or duplicate link is created |
+| 6 | Redirect target is unapproved | The flow forwards tokens or users to an attacker-controlled destination |
+| 7 | Requested scopes exceed policy | Broader access is granted without explicit approval |
+| 8 | Provider subject is already linked elsewhere | The existing link is silently reassigned |
+| 9 | Email or claim collides with another account | A guessed identity joins the wrong user |
+| 10 | Two link attempts run concurrently | Both succeed and create conflicting provider-link state |
+| 11 | Callback arrives after cancellation or expiry | A stale request still becomes active |
+| 12 | Token exchange succeeds but local write fails | Retrying creates a second link or loses the successful exchange |
+| 13 | Local write succeeds but response is lost | The user repeats the flow and duplicates the link or session |
+| 14 | Refresh token rotates | The old token remains active and breaks future recovery |
+| 15 | Provider revokes access later | Local state still shows an active trusted connection |
+| 16 | Cross-tenant provider identity is supplied | An identity from another tenant crosses the boundary |
+| 17 | Support or admin relink is attempted without authority | Privileged tooling bypasses normal ownership checks |
+| 18 | OAuth error details are logged | Tokens, claims, or secrets leak into logs or support traces |
+| 19 | Provider callback omits required claim data | The system invents or over-trusts missing identity fields |
+| 20 | Reconciliation runs after uncertain exchange status | Manual repair changes the wrong account or provider link |
+
+Full details are in [TESTING_GUIDE.md](TESTING_GUIDE.md).

--- a/prebuilt-workflow-paths/oauth-authorization-and-account-linking/ENGINEERING_GUIDE.md
+++ b/prebuilt-workflow-paths/oauth-authorization-and-account-linking/ENGINEERING_GUIDE.md
@@ -1,0 +1,30 @@
+# Engineering Guide
+
+## Trace the implementation
+1. Sign-in or link entry points, supported provider selection, and request validation
+2. Actor eligibility, tenant binding, local session state, and step-up requirements
+3. State, nonce, PKCE verifier, redirect URI, callback target, and expiry generation
+4. Provider authorization request construction, requested scopes, and consent flags
+5. Callback handler validation for provider, state, nonce, code, tenant, and local account context
+6. Code exchange, token parsing, claim retrieval, provider-subject normalization, and replay defense
+7. Local account resolution, create-versus-link decision, uniqueness constraints, and collision handling
+8. Token storage, encryption, rotation, revocation checks, audit, session creation, and user-visible status updates
+9. Retry, reconciliation, relink, disconnect prerequisite checks, and manual repair paths
+
+## Rules the code should protect
+- State, nonce, PKCE, provider, tenant, redirect, and local account are bound to one request record
+- Redirect URIs and post-login targets come from an allowlist, not raw user input
+- Provider subject, tenant, and trustable claims resolve to one local account outcome
+- Unique constraints and idempotent callback handling prevent duplicate sessions or provider-link rows
+- Scope changes, missing claims, provider errors, and denial responses are explicit states, not generic success
+- Tokens are encrypted or reference-stored, redacted in logs, and rotated or revoked by policy
+- Recovery distinguishes user cancellation, provider denial, exchange failure, and uncertain exchange success
+
+## Build or change safely
+1. Confirm provider, scope, account-matching, and trust decisions before relying on framework defaults.
+2. Follow existing authorization, session, token-storage, logging, monitoring, and test conventions.
+3. Bind every action to the authoritative actor, provider, tenant, request, state, and local account scope.
+4. Enforce permission, current-state, uniqueness, ordering, and expiry rules at the write.
+5. Make retries, callback replays, and lost responses safe after partial failure.
+6. Keep identity, token, and session inconsistency visible and repairable.
+7. Add the core 20 tests.

--- a/prebuilt-workflow-paths/oauth-authorization-and-account-linking/IMPLEMENT_WORKFLOW_SKILL.md
+++ b/prebuilt-workflow-paths/oauth-authorization-and-account-linking/IMPLEMENT_WORKFLOW_SKILL.md
@@ -1,0 +1,25 @@
+---
+name: implement-oauth-authorization-and-account-linking
+description: Implement or modify OAuth Authorization and Account Linking. Use when adding or changing validation, authorization, state transitions, identity binding, retries, recovery, privacy controls, monitoring, or tests.
+---
+
+# Implement OAuth Authorization and Account Linking
+
+Confirm:
+- Which providers, tenants, account types, and environments are supported
+- Whether the provider is used for login, linking, or both
+- Which scopes are mandatory, optional, incremental, or forbidden
+- How provider claims are trusted for account matching or first-time account creation
+- State, nonce, PKCE, redirect, callback-expiry, and session-binding policy
+- How existing links, email collisions, tenant mismatches, and relink requests are handled
+- Token storage, encryption, rotation, revocation, disconnect, and audit policy
+- Customer communication, support repair, abuse controls, privacy, and monitoring
+
+Follow project conventions and protect:
+- State, nonce, PKCE, provider, tenant, redirect, and local account binding
+- Safe account resolution, uniqueness, and collision handling
+- Explicit link, session, and token states
+- Replay-safe callback and reconciliation behavior
+- Protection of tokens, claims, personal data, and provider secrets
+
+Add all core tests and summarize decisions, files, state changes, recovery, privacy and security controls, and remaining gaps.

--- a/prebuilt-workflow-paths/oauth-authorization-and-account-linking/PATHS_AND_EDGE_CASES.md
+++ b/prebuilt-workflow-paths/oauth-authorization-and-account-linking/PATHS_AND_EDGE_CASES.md
@@ -1,0 +1,28 @@
+# Paths and Edge Cases
+
+## Supported paths
+- Signed-in user links an external provider to an existing local account
+- Returning user signs in through a previously linked provider subject
+- Policy allows first-time local account creation from trusted provider claims
+- Incremental consent adds an approved new scope to an existing provider link
+- Provider revocation or token rotation is detected and the link is updated safely
+
+## Denied or blocked paths
+- Actor lacks permission to create, relink, or use the provider connection
+- State, nonce, PKCE, issuer, tenant, or redirect binding is invalid
+- Requested or returned scopes exceed policy
+- Provider subject is already linked to another local account
+- Claims are missing, unverifiable, or collide with an unsafe account match
+
+## Timing and boundary cases
+- Two link flows complete at nearly the same time
+- Callback arrives after user cancellation or request expiry
+- Browser session changes between request creation and callback handling
+- Provider revokes access while the local session is still active
+- Token rotation occurs while another refresh or relink is in progress
+
+## Recovery-focused paths
+- Provider exchange succeeds but the local database update fails
+- Local write succeeds but the completion response is lost
+- Callback handling crashes after token receipt but before audit completion
+- Automated reconciliation repairs an uncertain link without reassignment

--- a/prebuilt-workflow-paths/oauth-authorization-and-account-linking/PERMISSION_AND_ABUSE_GUIDE.md
+++ b/prebuilt-workflow-paths/oauth-authorization-and-account-linking/PERMISSION_AND_ABUSE_GUIDE.md
@@ -1,0 +1,19 @@
+# Permission and Abuse Guide
+
+## Permission boundaries
+- Which actors may start login, create links, relink, disconnect, or use support tooling
+- Tenant, organization, environment, and provider-policy boundaries for every callback and token
+- Which scopes, claims, and account-creation paths are permitted for each actor type
+- Protection of tokens, provider subjects, emails, claims, audit entries, and redirect data
+
+## Misuse paths
+- Account takeover — A user is signed into or linked with another person's local account
+- Cross-tenant connection — An identity from one tenant gains access to another tenant's data or settings
+- Scope overreach — The application stores or uses broader permissions than the user approved
+- Duplicate or broken links — Replays or concurrent callbacks create conflicting provider-link records
+- False active connection — A revoked or expired provider relationship still appears usable
+- Silent identity collision — Email or claim matching joins the wrong local account
+- Token exposure — Access or refresh tokens leak through logs, support tools, or unsafe storage
+- Support-tool bypass — An operator relinks accounts without the right approval path
+
+Protect actor identity, tenant scope, provider subject ownership, tokens, support tools, and audit records. Deny uncertain ownership or permission.

--- a/prebuilt-workflow-paths/oauth-authorization-and-account-linking/PRODUCT_AND_BUSINESS_GUIDE.md
+++ b/prebuilt-workflow-paths/oauth-authorization-and-account-linking/PRODUCT_AND_BUSINESS_GUIDE.md
@@ -3,6 +3,12 @@
 ## Boundary
 Starts when an authenticated or eligibility-checked actor initiates sign-in with, connection to, or account linking for a supported external identity or data provider. Ends when the request is denied, cancelled, linked once with the approved scopes and subject bound to the correct local account, or remains explicitly uncertain with tokens, identity, permissions, and local account state reconciled.
 
+## Primary business outcome
+
+Establish or maintain exactly one authorized external-identity-to-local-account relationship with trustworthy identity, approved permissions, and recoverable state.
+
+Sign-in, account linking, sessions, tokens, revocation, and support repair are supporting lifecycle effects of this outcome; they are not separate primary workflows.
+
 ## People and systems
 - End user, administrator, or support-approved actor
 - Local application, session service, and account service

--- a/prebuilt-workflow-paths/oauth-authorization-and-account-linking/PRODUCT_AND_BUSINESS_GUIDE.md
+++ b/prebuilt-workflow-paths/oauth-authorization-and-account-linking/PRODUCT_AND_BUSINESS_GUIDE.md
@@ -1,0 +1,81 @@
+# Product and Business Guide
+
+## Boundary
+Starts when an authenticated or eligibility-checked actor initiates sign-in with, connection to, or account linking for a supported external identity or data provider. Ends when the request is denied, cancelled, linked once with the approved scopes and subject bound to the correct local account, or remains explicitly uncertain with tokens, identity, permissions, and local account state reconciled.
+
+## People and systems
+- End user, administrator, or support-approved actor
+- Local application, session service, and account service
+- OAuth or OIDC authorization server
+- External provider API or tenant directory
+- Risk, abuse, audit, and notification services
+- Support, security, privacy, and operations teams
+
+## Things created or changed
+- Link or sign-in request
+- State, nonce, PKCE verifier, and redirect context
+- Provider authorization code or device code if supported
+- Provider subject, tenant, approved scopes, and claims
+- Local account, login session, or provider-link record
+- Access token, refresh token, expiry, rotation status, and revocation state
+- Consent record, audit entry, and user-visible connection status
+
+## Stages
+- Link request: created → awaiting provider, callback received, approved, denied, cancelled, failed, or uncertain
+- Provider link: absent → pending → linked, relink required, revoked, or blocked
+- Local session: anonymous → challenged, authenticated, linked, or rejected
+- Token set: absent → active → rotated, expired, revoked, or uncertain
+
+## Product decisions
+- Which providers, tenants, account types, and environments are supported
+- Whether the flow is login-only, link-only, or allows both for the same provider
+- Which scopes are mandatory, optional, incremental, or forbidden
+- Whether new local accounts may be created automatically from provider claims
+- How email, phone, subject, tenant, and domain are trusted for account matching
+- State, nonce, PKCE, redirect, and callback-expiry policy
+- How an already-linked external account is handled when another local account tries to claim it
+- Session lifetime, step-up authentication, and support override policy
+- Token storage, encryption, rotation, revocation polling, and disconnect behavior
+- Customer communication, audit retention, abuse monitoring, and manual repair path
+
+## Happy paths
+- A signed-in user links one external provider account with the approved scopes
+- A returning user signs in through the same provider and is mapped to the correct local account
+- A provider rotates refresh tokens and the link remains valid without duplicate records
+
+## Negative paths
+- State, nonce, PKCE, redirect, subject, or tenant binding is invalid
+- The provider denies consent or returns an explicit error
+- The actor lacks permission to create or change the link
+- Provider claims collide with another local account or forbidden tenant
+
+## Edge cases
+- Two callbacks or link attempts arrive for the same request
+- A callback arrives after the user cancelled or the request expired
+- The provider succeeds but the local write or response fails
+- Scopes change between initial request and callback
+- The provider revokes or rotates tokens while local state still shows active
+
+## Acceptance criteria
+1. Only an eligible actor may start login or linking for the chosen provider and tenant context
+2. State, nonce, PKCE, redirect target, provider, tenant, and local account must bind to one request
+3. The approved provider subject must map to exactly one allowed local account outcome
+4. Consent, scopes, claims, and account-creation rules must follow explicit policy
+5. A provider account already linked elsewhere must not be silently reassigned
+6. Duplicate callbacks, code replay, and repeated exchanges must not create extra sessions or links
+7. Tokens, claims, and personal data must remain protected in storage, logs, and support tooling
+8. Uncertain exchange or callback outcomes must be reconciled before unsafe retry or relink
+9. Local connection status must stay consistent with provider revocation, expiry, and rotation state
+10. Every account-link change must be auditable and manually repairable
+
+## Business risks
+| Risk | Business consequence |
+|---|---|
+| Account takeover | A user is signed into or linked with another person's local account |
+| Cross-tenant connection | An identity from one tenant gains access to another tenant's data or settings |
+| Scope overreach | The application stores or uses broader permissions than the user approved |
+| Duplicate or broken links | Replays or concurrent callbacks create conflicting provider-link records |
+| False active connection | A revoked or expired provider relationship still appears usable |
+| Silent identity collision | Email or claim matching joins the wrong local account |
+| Token exposure | Access or refresh tokens leak through logs, support tools, or unsafe storage |
+| Unrepairable uncertainty | A successful provider exchange is lost locally and cannot be reconciled safely |

--- a/prebuilt-workflow-paths/oauth-authorization-and-account-linking/README.md
+++ b/prebuilt-workflow-paths/oauth-authorization-and-account-linking/README.md
@@ -1,0 +1,27 @@
+# OAuth Authorization and Account Linking
+
+Starts when an authenticated or eligibility-checked actor initiates sign-in with, connection to, or account linking for a supported external identity or data provider. Ends when the request is denied, cancelled, linked once with the approved scopes and subject bound to the correct local account, or remains explicitly uncertain with tokens, identity, permissions, and local account state reconciled.
+
+| Task | File |
+|---|---|
+| Product and business | [PRODUCT_AND_BUSINESS_GUIDE.md](PRODUCT_AND_BUSINESS_GUIDE.md) |
+| Engineering | [ENGINEERING_GUIDE.md](ENGINEERING_GUIDE.md) |
+| Testing | [TESTING_GUIDE.md](TESTING_GUIDE.md) |
+| Core 20 | [CORE_20_SCENARIOS.md](CORE_20_SCENARIOS.md) |
+| Paths and edge cases | [PATHS_AND_EDGE_CASES.md](PATHS_AND_EDGE_CASES.md) |
+| Permissions and misuse | [PERMISSION_AND_ABUSE_GUIDE.md](PERMISSION_AND_ABUSE_GUIDE.md) |
+| Retry and recovery | [RETRY_AND_RECOVERY_GUIDE.md](RETRY_AND_RECOVERY_GUIDE.md) |
+
+## Included
+- provider selection, supported flow choice, state, nonce, PKCE, redirect, and callback binding
+- actor eligibility, tenant and environment binding, scope approval, subject mapping, and local account selection
+- sign-in, first-time account creation, existing-account linking, token exchange, refresh-token rotation, and audit
+- duplicate callback defense, replay prevention, permission changes, revocation awareness, privacy, retry, recovery, and misuse
+
+## Excluded
+- local username-password authentication that does not involve an external provider
+- post-link data synchronization, import, or background webhook ingestion
+- ongoing resource authorization that uses an already-linked identity
+- disconnect, full account deletion, and enterprise-provisioning lifecycle
+
+The five `*_SKILL.md` files are self-contained.

--- a/prebuilt-workflow-paths/oauth-authorization-and-account-linking/RETRY_AND_RECOVERY_GUIDE.md
+++ b/prebuilt-workflow-paths/oauth-authorization-and-account-linking/RETRY_AND_RECOVERY_GUIDE.md
@@ -1,0 +1,14 @@
+# Retry and Recovery Guide
+
+## Partial failures
+- Provider code exchange succeeds but the application crashes before persisting the link
+- Local link persists but the redirect response or session cookie is lost
+- Token refresh rotates credentials while another worker still uses the old token
+- Revocation or relink state changes arrive out of order
+
+## Recovery rules
+- Use request, provider, issuer, subject, tenant, local account, and token identities consistently.
+- Retry callback handling only with replay-safe request records and uniqueness constraints.
+- Record explicit uncertain states instead of guessing whether login or linking completed.
+- Reconcile provider subject, scope, token status, local link row, session, and audit to one outcome.
+- Keep a manual repair path that can verify the correct local account before changing any link assignment.

--- a/prebuilt-workflow-paths/oauth-authorization-and-account-linking/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/oauth-authorization-and-account-linking/REVIEW_BUSINESS_RISK_SKILL.md
@@ -1,0 +1,18 @@
+---
+name: review-oauth-authorization-and-account-linking-risk
+description: Review account-takeover, scope, tenant, privacy, and operational risks in OAuth Authorization and Account Linking. Use when founders, PMs, or engineering managers need prioritized consequences, controls, tests, and release concerns.
+---
+
+# Review OAuth Authorization and Account Linking Risk
+
+Review entry, identity proof, account matching, state, timing, concurrency, external effects, retry, recovery, privacy, and support paths. Prioritize:
+- Account takeover — A user is signed into or linked with another person's local account
+- Cross-tenant connection — An identity from one tenant gains access to another tenant's data or settings
+- Scope overreach — The application stores or uses broader permissions than the user approved
+- Duplicate or broken links — Replays or concurrent callbacks create conflicting provider-link records
+- False active connection — A revoked or expired provider relationship still appears usable
+- Silent identity collision — Email or claim matching joins the wrong local account
+- Token exposure — Access or refresh tokens leak through logs, support tools, or unsafe storage
+- Unrepairable uncertainty — A successful provider exchange is lost locally and cannot be reconciled safely
+
+For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition.

--- a/prebuilt-workflow-paths/oauth-authorization-and-account-linking/TESTING_GUIDE.md
+++ b/prebuilt-workflow-paths/oauth-authorization-and-account-linking/TESTING_GUIDE.md
@@ -1,0 +1,243 @@
+# Testing Guide
+
+Check account identity, tenant binding, consent scope, token safety, session outcomes, recovery, and audit, not only redirect success.
+
+## 1. Eligible user links a provider account once
+
+**Given:** A signed-in eligible user starts linking with an approved provider and scope set
+
+**When:** The flow completes successfully
+
+**Expect:** One provider subject is linked to one local account and the visible connection state becomes active
+
+**Must not happen:** One provider account creates duplicate local links
+
+**Best test levels:** End-to-end and integration.
+
+## 2. Returning user signs in with the linked provider
+
+**Given:** A provider subject is already linked to a local account
+
+**When:** The user signs in through that provider again
+
+**Expect:** The same local account and permitted session are restored
+
+**Must not happen:** The provider subject maps to the wrong local account
+
+**Best test levels:** End-to-end.
+
+## 3. State or PKCE verifier is missing or wrong
+
+**Given:** A callback arrives with altered, missing, or mismatched state, nonce, or PKCE data
+
+**When:** Callback validation runs
+
+**Expect:** The flow is rejected before token exchange or session creation
+
+**Must not happen:** The callback still creates a session or link
+
+**Best test levels:** Security and integration.
+
+## 4. Provider denies consent
+
+**Given:** The user rejects consent or the provider returns an OAuth denial error
+
+**When:** The callback is handled
+
+**Expect:** The request ends in a denied state with no new link or login session
+
+**Must not happen:** Denial is stored as a successful connection
+
+**Best test levels:** Provider contract and end-to-end.
+
+## 5. Callback code is replayed
+
+**Given:** A valid authorization code or callback payload is submitted more than once
+
+**When:** Exchange or callback handling runs again
+
+**Expect:** The replay is recognized and no duplicate side effect occurs
+
+**Must not happen:** A second session or duplicate link is created
+
+**Best test levels:** Security and integration.
+
+## 6. Redirect target is unapproved
+
+**Given:** A request contains an altered callback target or post-login destination
+
+**When:** Redirect allowlist checks run
+
+**Expect:** The destination is rejected or normalized to a safe target
+
+**Must not happen:** The flow forwards tokens or users to an attacker-controlled destination
+
+**Best test levels:** Security and API.
+
+## 7. Requested scopes exceed policy
+
+**Given:** The client or provider response includes scopes outside the product policy
+
+**When:** Scope validation and consent recording run
+
+**Expect:** The flow blocks, downgrades, or requires explicit approval by policy
+
+**Must not happen:** Broader access is granted without explicit approval
+
+**Best test levels:** Unit and integration.
+
+## 8. Provider subject is already linked elsewhere
+
+**Given:** The external provider account already belongs to another local account
+
+**When:** A second account tries to link it
+
+**Expect:** The new request is denied or routed to an explicit manual recovery path
+
+**Must not happen:** The existing link is silently reassigned
+
+**Best test levels:** Integration and security.
+
+## 9. Email or claim collides with another account
+
+**Given:** Provider claims match an email, alias, or identifier already present on another account
+
+**When:** Local account resolution runs
+
+**Expect:** Trust rules require explicit verified matching or manual resolution
+
+**Must not happen:** A guessed identity joins the wrong user
+
+**Best test levels:** Unit, integration, and security.
+
+## 10. Two link attempts run concurrently
+
+**Given:** The same user or provider subject starts two link flows at nearly the same time
+
+**When:** Both callbacks complete
+
+**Expect:** Uniqueness and idempotency allow one consistent link outcome
+
+**Must not happen:** Both succeed and create conflicting provider-link state
+
+**Best test levels:** Concurrency integration.
+
+## 11. Callback arrives after cancellation or expiry
+
+**Given:** The link request has been cancelled, timed out, or invalidated
+
+**When:** A late callback arrives
+
+**Expect:** The callback is rejected or recorded as stale without new trust
+
+**Must not happen:** A stale request still becomes active
+
+**Best test levels:** Integration with controlled time.
+
+## 12. Token exchange succeeds but local write fails
+
+**Given:** The provider returned tokens successfully but the database update fails
+
+**When:** Recovery or retry runs
+
+**Expect:** The same exchange is reconciled safely without duplicating the link
+
+**Must not happen:** Retrying creates a second link or loses the successful exchange
+
+**Best test levels:** Integration and operations.
+
+## 13. Local write succeeds but response is lost
+
+**Given:** The local link or session is created but the user receives no completion response
+
+**When:** The user restarts the same flow
+
+**Expect:** The application returns the existing link or session result safely
+
+**Must not happen:** The user repeats the flow and duplicates the link or session
+
+**Best test levels:** End-to-end and integration.
+
+## 14. Refresh token rotates
+
+**Given:** The provider issues a new refresh token and invalidates the previous one
+
+**When:** Token update handling runs
+
+**Expect:** The new token replaces the old one atomically and future refresh still works
+
+**Must not happen:** The old token remains active and breaks future recovery
+
+**Best test levels:** Provider contract and integration.
+
+## 15. Provider revokes access later
+
+**Given:** The user or provider revokes the application's access after successful linking
+
+**When:** Refresh, webhook, or status check detects revocation
+
+**Expect:** Local connection state becomes revoked or relink-required and protected actions stop
+
+**Must not happen:** Local state still shows an active trusted connection
+
+**Best test levels:** Integration and operations.
+
+## 16. Cross-tenant provider identity is supplied
+
+**Given:** A provider identity belongs to another tenant, organization, or configured environment
+
+**When:** The actor attempts login or linking
+
+**Expect:** Tenant and environment binding deny the connection
+
+**Must not happen:** An identity from another tenant crosses the boundary
+
+**Best test levels:** Authorization and security.
+
+## 17. Support or admin relink is attempted without authority
+
+**Given:** Privileged tooling can modify provider links on behalf of users
+
+**When:** An operator without sufficient approval attempts a relink
+
+**Expect:** Elevated checks, audit, and policy controls block or record the action explicitly
+
+**Must not happen:** Privileged tooling bypasses normal ownership checks
+
+**Best test levels:** Security and administrative integration.
+
+## 18. OAuth error details are logged
+
+**Given:** The path contains tokens, claims, provider payloads, redirect data, and client identifiers
+
+**When:** Any validation or exchange step fails
+
+**Expect:** Logs remain diagnosable while redacting secrets and sensitive identity data
+
+**Must not happen:** Tokens, claims, or secrets leak into logs or support traces
+
+**Best test levels:** Security and log inspection.
+
+## 19. Provider callback omits required claim data
+
+**Given:** Required subject, tenant, email-verification, or issuer claims are missing or malformed
+
+**When:** Account resolution and trust checks run
+
+**Expect:** The flow blocks, requests another step, or escalates to manual review
+
+**Must not happen:** The system invents or over-trusts missing identity fields
+
+**Best test levels:** Unit and integration.
+
+## 20. Reconciliation runs after uncertain exchange status
+
+**Given:** The application cannot tell whether the provider code exchange completed and whether a link already exists
+
+**When:** Manual or automated reconciliation runs
+
+**Expect:** Repair uses provider subject, request record, audit, and current local state to converge safely
+
+**Must not happen:** Manual repair changes the wrong account or provider link
+
+**Best test levels:** Operations and integration.

--- a/prebuilt-workflow-paths/oauth-authorization-and-account-linking/TESTING_GUIDE.md
+++ b/prebuilt-workflow-paths/oauth-authorization-and-account-linking/TESTING_GUIDE.md
@@ -52,15 +52,21 @@ Check account identity, tenant binding, consent scope, token safety, session out
 
 ## 5. Callback code is replayed
 
-**Given:** A valid authorization code or callback payload is submitted more than once
+**Given:** A valid authorization code and callback context have been accepted once, and the same callback payload is submitted again
 
-**When:** Exchange or callback handling runs again
+**When:** Callback handling or token exchange runs for the replayed request
 
-**Expect:** The replay is recognized and no duplicate side effect occurs
+**Expect:** The replay is detected using the request/code state, and the existing outcome is returned or the replay is rejected without a new side effect
 
-**Must not happen:** A second session or duplicate link is created
+**Must not happen:** A second session, provider link, token set, or account-linking side effect is created
 
-**Best test levels:** Security and integration.
+**Fixtures:** Persist one valid authorization request, provider subject, local account, and completed callback outcome
+
+**Controlled provider behavior:** Return the same authorization code or replayable callback payload on the second submission
+
+**Best test levels:** Security and integration
+
+**Cleanup:** Remove the authorization request, provider-link state, session, and test provider state
 
 ## 6. Redirect target is unapproved
 
@@ -112,15 +118,21 @@ Check account identity, tenant binding, consent scope, token safety, session out
 
 ## 10. Two link attempts run concurrently
 
-**Given:** The same user or provider subject starts two link flows at nearly the same time
+**Given:** The same local account and provider subject have two valid link requests started at nearly the same time
 
-**When:** Both callbacks complete
+**When:** Both callbacks reach account resolution and provider-link persistence concurrently
 
-**Expect:** Uniqueness and idempotency allow one consistent link outcome
+**Expect:** Transactional and uniqueness controls converge both requests on one consistent provider-link outcome
 
-**Must not happen:** Both succeed and create conflicting provider-link state
+**Must not happen:** Both requests create conflicting provider-link records, reassign ownership, or create duplicate sessions
 
-**Best test levels:** Concurrency integration.
+**Fixtures:** Create one local account and provider subject with two independent authorization requests
+
+**Controlled concurrency:** Release both callback handlers at the same synchronization point before persistence
+
+**Best test levels:** Concurrency integration and database integration
+
+**Cleanup:** Remove the authorization requests, provider link, sessions, and test provider state.
 
 ## 11. Callback arrives after cancellation or expiry
 
@@ -136,15 +148,21 @@ Check account identity, tenant binding, consent scope, token safety, session out
 
 ## 12. Token exchange succeeds but local write fails
 
-**Given:** The provider returned tokens successfully but the database update fails
+**Given:** The provider successfully exchanges the authorization code and returns valid tokens, but the local persistence operation fails before the link is durably recorded
 
-**When:** Recovery or retry runs
+**When:** Recovery or retry runs after the partial failure
 
-**Expect:** The same exchange is reconciled safely without duplicating the link
+**Expect:** The application reconciles the provider result with the existing request and local state without repeating an unsafe exchange or creating a duplicate link
 
-**Must not happen:** Retrying creates a second link or loses the successful exchange
+**Must not happen:** Retrying creates a second provider link, loses the successful exchange permanently, or creates a session without a valid local link
 
-**Best test levels:** Integration and operations.
+**Fixtures:** Create a valid authorization request and configure the persistence layer to fail once after successful provider exchange
+
+**Controlled provider behavior:** Return a deterministic successful token exchange without issuing a different provider subject on retry
+
+**Best test levels:** Integration and failure-injection testing
+
+**Cleanup:** Remove the authorization request, provider-link state, tokens, sessions, and injected failure configuration
 
 ## 13. Local write succeeds but response is lost
 
@@ -160,15 +178,21 @@ Check account identity, tenant binding, consent scope, token safety, session out
 
 ## 14. Refresh token rotates
 
-**Given:** The provider issues a new refresh token and invalidates the previous one
+**Given:** An active provider connection has a current refresh token and the provider rotates it during a refresh operation
 
-**When:** Token update handling runs
+**When:** The application receives a new refresh token and persists the rotated token
 
-**Expect:** The new token replaces the old one atomically and future refresh still works
+**Expect:** The new token becomes authoritative atomically, the previous token is no longer accepted for future refreshes, and the provider link remains active
 
-**Must not happen:** The old token remains active and breaks future recovery
+**Must not happen:** The old token remains authoritative, concurrent refreshes overwrite the newest token incorrectly, or a failed rotation leaves the connection falsely active
 
-**Best test levels:** Provider contract and integration.
+**Fixtures:** Create an active provider link with a known current refresh token and persisted rotation state
+
+**Controlled provider behavior:** Return a replacement refresh token and invalidate the previous token
+
+**Best test levels:** Provider contract, integration, and concurrency testing
+
+**Cleanup:** Revoke or delete test tokens and remove the provider link and session state
 
 ## 15. Provider revokes access later
 
@@ -232,12 +256,18 @@ Check account identity, tenant binding, consent scope, token safety, session out
 
 ## 20. Reconciliation runs after uncertain exchange status
 
-**Given:** The application cannot tell whether the provider code exchange completed and whether a link already exists
+**Given:** The application cannot determine whether a provider code exchange completed because the response was lost or the local operation timed out
 
-**When:** Manual or automated reconciliation runs
+**When:** Automated or manual reconciliation examines the authorization request, provider identity, audit trail, and current local state
 
-**Expect:** Repair uses provider subject, request record, audit, and current local state to converge safely
+**Expect:** Reconciliation determines whether the exchange and link already succeeded and converges the request to one authoritative outcome
 
-**Must not happen:** Manual repair changes the wrong account or provider link
+**Must not happen:** Reconciliation creates a duplicate link, assigns the provider identity to the wrong local account, exchanges the same one-time code unsafely, or overwrites a valid newer state
 
-**Best test levels:** Operations and integration.
+**Fixtures:** Create an authorization request with an uncertain exchange status and optionally persist evidence of a completed provider exchange
+
+**Controlled provider behavior:** Simulate a successful exchange whose response is lost, followed by a reconciliation lookup
+
+**Best test levels:** Integration and operations testing
+
+**Cleanup:** Remove the authorization request, reconciliation records, provider-link state, audit entries, tokens, and test provider state

--- a/prebuilt-workflow-paths/oauth-authorization-and-account-linking/TEST_WORKFLOW_SKILL.md
+++ b/prebuilt-workflow-paths/oauth-authorization-and-account-linking/TEST_WORKFLOW_SKILL.md
@@ -1,0 +1,30 @@
+---
+name: test-oauth-authorization-and-account-linking
+description: Design, implement, or review tests for OAuth Authorization and Account Linking. Use when complete normal, invalid, boundary, concurrency, replay, failure, recovery, permission, privacy, and misuse scenarios are needed.
+---
+
+# Test OAuth Authorization and Account Linking
+
+Cover:
+1. Eligible user links a provider account once
+2. Returning user signs in with the linked provider
+3. State or PKCE verifier is missing or wrong
+4. Provider denies consent
+5. Callback code is replayed
+6. Redirect target is unapproved
+7. Requested scopes exceed policy
+8. Provider subject is already linked elsewhere
+9. Email or claim collides with another account
+10. Two link attempts run concurrently
+11. Callback arrives after cancellation or expiry
+12. Token exchange succeeds but local write fails
+13. Local write succeeds but response is lost
+14. Refresh token rotates
+15. Provider revokes access later
+16. Cross-tenant provider identity is supplied
+17. Support or admin relink is attempted without authority
+18. OAuth error details are logged
+19. Provider callback omits required claim data
+20. Reconciliation runs after uncertain exchange status
+
+For each scenario write Given, When, expected response and authoritative state changes, forbidden outcomes, test level, fixtures, controlled time or provider behavior, and cleanup.

--- a/prebuilt-workflow-paths/oauth-authorization-and-account-linking/UNDERSTAND_CODE_SKILL.md
+++ b/prebuilt-workflow-paths/oauth-authorization-and-account-linking/UNDERSTAND_CODE_SKILL.md
@@ -1,0 +1,15 @@
+---
+name: understand-oauth-authorization-and-account-linking-code
+description: Trace and explain OAuth Authorization and Account Linking across an existing codebase. Use when locating entry points, authorization, state, provider calls, account matching, retries, recovery, monitoring, and tests.
+---
+
+# Understand OAuth Authorization and Account Linking Code
+
+Trace:
+1. Sign-in or link entry points, provider selection, and redirect construction
+2. State, nonce, PKCE, callback, issuer, tenant, and account binding
+3. Token exchange, claim normalization, account resolution, and unique-link constraints
+4. Token storage, refresh, revocation, session creation, and support tooling
+5. Retry, reconciliation, relink, and manual-repair logic
+
+Explain actors, ownership, trust rules, states, transitions, effects, failures, retries, security boundaries, monitoring, tests, and areas needing verification. Cite files and symbols.

--- a/prebuilt-workflow-paths/oauth-authorization-and-account-linking/WRITE_PRODUCT_SPEC_SKILL.md
+++ b/prebuilt-workflow-paths/oauth-authorization-and-account-linking/WRITE_PRODUCT_SPEC_SKILL.md
@@ -1,0 +1,18 @@
+---
+name: write-oauth-authorization-and-account-linking-spec
+description: Write or review a product specification for OAuth Authorization and Account Linking. Use when defining actors, states, trust rules, scope policy, account-matching rules, token handling, recovery, or business risks.
+---
+
+# Write an OAuth Authorization and Account Linking Specification
+
+Use application-native terms. Decide:
+- Which providers, tenants, account types, and environments are supported
+- Whether the provider is used for login, linking, or both
+- Which scopes are mandatory, optional, incremental, or forbidden
+- How provider claims are trusted for account matching or first-time account creation
+- State, nonce, PKCE, redirect, callback-expiry, and session-binding policy
+- How existing links, email collisions, tenant mismatches, and relink requests are handled
+- Token storage, encryption, rotation, revocation, disconnect, and audit policy
+- Customer communication, support repair, abuse controls, privacy, and monitoring
+
+Write scope, actors, objects, states, paths, permissions, trust rules, consent, recovery, privacy, misuse, acceptance criteria, and unanswered decisions.


### PR DESCRIPTION
## Problem and scope

Add a reusable OAuth Authorization and Account Linking workflow pack for analyzing the business and engineering risks involved in establishing and maintaining an authorized external-identity-to-local-account relationship.

The workflow covers sign-in/link initiation through callback handling, account resolution, token/session state, revocation, failure recovery, and reconciliation. It explicitly defines the primary business outcome, included/excluded scope, lifecycle stages, permissions, security boundaries, and recovery paths.

## What changed

* Added the complete 13-file OAuth Authorization and Account Linking workflow pack.
* Added exactly 20 distinct core scenarios covering:

  * OAuth state, nonce, and PKCE validation
  * Account and identity collisions
  * Redirect and scope security
  * Callback replay and concurrency
  * Partial completion and lost responses
  * Token rotation and revocation
  * Cross-tenant identity isolation
  * Privileged support/admin relinking
  * Sensitive data and logging protection
  * Retry, recovery, and uncertain-exchange reconciliation
* Added detailed testing guidance with fixtures, controlled provider/time behaviour, test levels, and cleanup guidance for failure-prone scenarios.
* Defined one primary business outcome: safely establishing or maintaining exactly one authorized external-identity-to-local-account relationship with trustworthy identity, approved permissions, and recoverable state.
* Added five task-specific LLM skills covering product specification, business-risk review, code understanding, implementation, and testing.
* Linked the new workflow pack from `prebuilt-workflow-paths/README.md`.

## Verification

* [x] `python -m black --config .github/quality/pyproject.toml --check .github/quality/tests`
* [x] `python -m flake8 --config .github/quality/.flake8 .github/quality/tests`
* [x] `python -m pytest -c .github/quality/pyproject.toml .github/quality/tests`
* [x] 632 repository quality tests passed.
* [x] `git diff --check` passed.
* [x] Workflow pack contains all 13 required files.
* [x] Exactly 20 core scenarios are present.
* [x] Every core scenario specifies what must not happen.
* [x] No credentials, proprietary source, customer data, or generated customer reports are included.

### UnvibeCode repository trial

- [x] Reviewed the public `pallets/flask` repository using UnvibeCode 0.3.3.
- [x] Repository size: approximately 188,011 tokens across 105 source files.
- [x] Reviewed the Connected Code Map, Business Workflow Map, and Business Risk Findings outputs.
- [x] The Business Workflow Map reconstructed 18 workflows across 11 business areas.
- [x] The Business Risk Findings report identified no confirmed business flaw that passed the business-impact gate.
- [x] The review surfaced `wrappers.py`, `testing.py`, and `templating.py` as structural review priorities because of their high connectivity/dependency relationships.
- [x] No proprietary source, credentials, customer data, or generated customer reports were included in this PR.

## Workflow-pack checks

* [x] The start, end, included scope, and excluded scope are explicit.
* [x] The pack owns one primary business outcome and does not duplicate an existing pack.
* [x] The 20 core scenarios are distinct and collectively cover the declared boundary.
* [x] Every core scenario states what must not happen.
* [x] All 13 required files use consistent People and systems, Things created or changed, Stages, and outcome terminology.

## Remaining limitations

This is a reusable workflow specification rather than an implementation for a specific OAuth provider or application. Provider-specific contracts, account-matching rules, token storage mechanisms, regulatory requirements, and application-native identity models still need to be adapted to the repository being reviewed.

The Flask repository trial was used to validate the review workflow and inspect its generated outputs; it was not treated as an OAuth-specific implementation target.