### PR TITLE
[Improvement] Add Required Skills to Business Risk reviews (#69)

### DIFF
--- a/.github/quality/tests/test_repository_quality.py
+++ b/.github/quality/tests/test_repository_quality.py
@@ -64,6 +64,27 @@ def test_workflow_skills_have_frontmatter(pack):
         assert re.search(r"^description:\s*\S+", frontmatter, re.MULTILINE), filename
 
 
+@pytest.mark.parametrize("pack", workflow_packs(), ids=lambda path: path.name)
+def test_review_business_risk_skill_requires_developer_skills(pack):
+    content = (pack / "REVIEW_BUSINESS_RISK_SKILL.md").read_text(encoding="utf-8")
+    lowered = content.lower()
+
+    # The skill must instruct the reviewer to name required developer skills
+    # for each material risk, not just leave it as a documentation aside.
+    assert "required skills:" in lowered
+    assert "for each material risk" in lowered
+    assert "required skills" in lowered.split("for each material risk", 1)[1]
+
+    # The instruction must ground skills in the risk evidence rather than
+    # allowing invented or generic technologies.
+    assert "derive required skills" in lowered
+    assert "do not invent" in lowered
+
+    # It must define a fallback instead of guessing when no specialised
+    # expertise can be inferred from the evidence.
+    assert "instead of guessing" in lowered
+
+
 def test_pack_index_links_every_workflow_pack():
     index = (PACKS_ROOT / "README.md").read_text(encoding="utf-8")
     for pack in workflow_packs():

--- a/prebuilt-workflow-paths/account-data-deletion-and-right-to-erasure/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/account-data-deletion-and-right-to-erasure/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, identity, authorization, policy, state, timing, concurrency, exter
 - Cross-tenant deletion — Shared identifiers or jobs remove another customer's records
 - Sensitive-data exposure — Identity proof, inventory, retained data, or deletion evidence reaches unsafe logs
 
-For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/booking-cancellation-capacity-release-and-refund/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/booking-cancellation-capacity-release-and-refund/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, quantity or money, authorization, state, timing, concurrency, exte
 - Cancellation after service — Stale action reverses a completed or checked-in booking
 - Personal-data exposure — Schedule, customer, reason, payment, or provider data reaches unsafe logs
 
-For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/booking-confirmation-and-capacity-reservation/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/booking-confirmation-and-capacity-reservation/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, quantity or money, authorization, state, timing, concurrency, exte
 - False confirmation — The customer receives success while provider or capacity commitment is missing
 - Personal-data exposure — Contact, attendee, schedule, payment, or provider data reaches unsafe logs
 
-For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/checkout-payment-authorization-and-capture/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/checkout-payment-authorization-and-capture/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, amount or access, authorization, state, timing, concurrency, exter
 - Card-testing or cost abuse — Automated attempts create fraud, provider fees, or customer harm
 - Secret or personal-data exposure — Payment data, tokens, provider responses, or credentials reach unsafe logs
 
-For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/customer-support-ticket-management/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/customer-support-ticket-management/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, validation, authorization, state, timing, concurrency, external ef
 - Duplicate business action — Retries repeat refunds, credits, notifications, or account changes
 - Sensitive-data exposure — Messages, attachments, credentials, or personal data reach unsafe logs or recipients
 
-For each material risk, explain the trigger, current or expected behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain the trigger, current or expected behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/external-system-data-sync-and-checkpointing/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/external-system-data-sync-and-checkpointing/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, authentication or connection, tenant mapping, state, ordering, pro
 - Runaway provider load — Paging, retries, or cursor loops consume quotas and cost
 - Credential or data exposure — Tokens, source records, personal data, or errors reach unsafe logs
 
-For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/failed-notification-retry-and-channel-fallback/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/failed-notification-retry-and-channel-fallback/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, validation, authorization, state, timing, concurrency, external ef
 - Stale-status conflict — Late callbacks and active retries disagree and move the message backward
 - Secret or personal-data exposure — Fallback adaptation, provider errors, and diagnostics reveal protected content
 
-For each material risk, explain the trigger, current or expected behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain the trigger, current or expected behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/fraud-risk-check-step-up-block-and-investigation/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/fraud-risk-check-step-up-block-and-investigation/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, identity, authorization, policy, state, timing, concurrency, exter
 - Adversarial probing — Repeated requests reveal thresholds or evade controls
 - Sensitive-data exposure — Device, identity, payment, scores, rules, or evidence reach unsafe logs
 
-For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/inventory-reservation-release-and-expiry/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/inventory-reservation-release-and-expiry/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, amount or quantity, authorization, state, timing, concurrency, ext
 - Multi-location inconsistency — Databases, caches, sellers, or warehouses disagree
 - Reservation hoarding — Automated demand blocks scarce stock and harms real customers
 
-For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/llm-content-generation-and-output-validation/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/llm-content-generation-and-output-validation/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, authorization, prompt or source, versions, validation or evidence,
 - Version inconsistency — Prompt, schema, policy, or model changes make retries and outputs irreproducible
 - Secret or personal-data exposure — Prompts, responses, credentials, or provider errors reach unsafe storage or logs
 
-For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/marketplace-fees-split-payouts-and-settlement/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/marketplace-fees-split-payouts-and-settlement/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, evidence or money, authorization, state, timing, concurrency, exte
 - Unauthorized manual adjustment — A privileged action changes fees, payees, holds, or payout state improperly
 - Sensitive-data exposure — Bank, tax, balance, transaction, or provider data reaches unsafe logs
 
-For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/multi-step-approval-and-rejection/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/multi-step-approval-and-rejection/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, validation, authorization, state, timing, concurrency, external ef
 - SLA or escalation failure — Important requests remain unattended or go to the wrong substitute
 - Evidence exposure — Sensitive request data or reviewer comments reach the wrong audience or logs
 
-For each material risk, explain the trigger, current or expected behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain the trigger, current or expected behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/order-placement-and-confirmation/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/order-placement-and-confirmation/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, amount or quantity, authorization, state, timing, concurrency, ext
 - False confirmation — Customer receives success while fulfilment prerequisites are missing
 - Personal-data exposure — Addresses, customer data, pricing, tokens, or internal decisions reach unsafe logs
 
-For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/rag-question-answering-with-evidence-and-citations/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/rag-question-answering-with-evidence-and-citations/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, authorization, prompt or source, versions, validation or evidence,
 - False confidence — Insufficient or conflicting evidence is presented without qualification
 - Sensitive-data exposure — Queries, documents, answers, embeddings, or credentials reach unsafe logs
 
-For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/scheduled-job-execution-retry-and-recovery/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/scheduled-job-execution-retry-and-recovery/REVIEW_BUSINESS_RISK_SKILL.md
@@ -17,5 +17,5 @@ Review schedule, entry, identity, authorization, ownership, windows, state, timi
 - Unrecoverable poison item — One bad record blocks the schedule forever or is silently discarded
 - Sensitive-data exposure — Job inputs, outputs, credentials, or failure payloads reach unsafe logs or operators
 
-For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/seller-and-service-provider-onboarding/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/seller-and-service-provider-onboarding/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, evidence or money, authorization, state, timing, concurrency, exte
 - Payout or account mismatch — Revenue routes to an account not bound to the approved provider
 - Sensitive-data exposure — Identity, ownership, bank, tax, or review evidence reaches unsafe audiences or logs
 
-For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/subscription-renewal-cancellation-and-access-removal/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/subscription-renewal-cancellation-and-access-removal/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, amount or access, authorization, state, timing, concurrency, exter
 - Hidden or ineffective cancellation — The customer believes renewal stopped but billing continues
 - Sensitive-data exposure — Billing, payment, cancellation, or account data reaches unsafe logs
 
-For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 

--- a/prebuilt-workflow-paths/transactional-notification-delivery/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/transactional-notification-delivery/REVIEW_BUSINESS_RISK_SKILL.md
@@ -15,5 +15,5 @@ Review entry, validation, authorization, state, timing, concurrency, external ef
 - Message amplification — One event or attacker triggers unbounded provider traffic and cost
 - Secret or personal-data exposure — Destinations, content, tokens, provider responses, or credentials reach unsafe logs
 
-For each material risk, explain the trigger, current or expected behavior, business consequence, protection, decision or test, and acceptance condition.
+For each material risk, explain the trigger, current or expected behavior, business consequence, protection, decision or test, and acceptance condition. Also state Required Skills: the specific developer expertise (for example, programming language, framework or library, database technology, authentication/authorization, concurrency, idempotency, transaction management, webhook handling, queue processing, caching, external integration, API design, or infrastructure/deployment concern) needed to understand and fix the risk. Derive Required Skills only from the trigger, behavior, and affected code or workflow already identified for that risk; do not invent technologies or expertise the evidence does not support, and keep the list concise. If no specialised expertise beyond general application development is evident, say so instead of guessing.
 


### PR DESCRIPTION
## Summary

Adds a `Required Skills` requirement to all 18 Business Risk review skills so that each material risk identifies the specific developer expertise needed to understand and resolve it.

## What changed

* Updated all 18 `REVIEW_BUSINESS_RISK_SKILL.md` files.
* Added an explicit `Required Skills` requirement to the Business Risk output contract.
* Required skills are grounded in the identified trigger, behavior, and affected code/workflow.
* Explicitly prevents unsupported or invented technologies from being listed.
* Provides a fallback when no specialised expertise can reasonably be inferred.
* Added a parametrized repository-quality regression test covering all 18 workflow packs.

## Validation

* Black: passed
* Flake8: passed
* Pytest: **634 passed**
* `git diff --check`: passed
* Regression test covers all 18 Business Risk skill files.

## Scope

This implements the Required Skills requirement at the public workflow-skill layer.

The hosted Business Risk analysis engine and `03_business_risk_findings.html` renderer referenced by the issue are closed-source and are not present in this repository. Therefore, this PR does not modify that hosted renderer; it updates the public Business Risk skill instructions that are maintained in this repository.

Addresses #69.
