### PR TITLE
[Challenge 2026][Improvement] Add installation verification step to Quick Start

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -16,6 +16,14 @@ Install UnvibeCode:
 python -m pip install --upgrade unvibecode
 ```
 
+Verify the installation:
+
+```powershell
+python -m unvibecode --help
+```
+
+You should see the list of available commands. If you see `No module named unvibecode`, see [Troubleshooting](TROUBLESHOOTING.md).
+
 Review a repository:
 
 ```powershell
@@ -29,6 +37,14 @@ Install UnvibeCode:
 ```bash
 python3 -m pip install --upgrade unvibecode
 ```
+
+Verify the installation:
+
+```bash
+python3 -m unvibecode --help
+```
+
+You should see the list of available commands. If you see `No module named unvibecode`, see [Troubleshooting](TROUBLESHOOTING.md).
 
 Review a repository:
 


### PR DESCRIPTION
Adds a "Verify the installation" step to docs/QUICKSTART.md for both Windows and macOS/Linux, run right after install and before the first repository review.

Problem: the Quick Start goes straight from install to running a full review. If the install landed in the wrong Python environment, the first sign of trouble is a failed review rather than a quick check. Troubleshooting.md's first entry is exactly this case ("No module named unvibecode"), but a new user only finds it after failing.

Change: added python -m unvibecode --help (Windows) / python3 -m unvibecode --help (macOS/Linux) as a verification step, with a one-line pointer to Troubleshooting.md if it fails.

Verified: ran pip install unvibecode fresh and confirmed --help prints available commands; confirmed the added Markdown link resolves correctly.