### PR TITLE
Add Vibecoding to Verified Engineering guide

### DIFF
--- a/AI Engineering Cheatsheet/README.md
+++ b/AI Engineering Cheatsheet/README.md
@@ -36,6 +36,10 @@ Twenty-six production failure patterns with symptoms, failure mechanisms, safer 
 
 Forty recurring production decisions across model behaviour, RAG, agents, reliability, safety, evaluation, and operations. Each comparison includes the advantages, disadvantages, and a practical decision rule.
 
+### [From Vibecoding to Verified Engineering](./VIBECODING_TO_VERIFIED_ENGINEERING_GUIDE.md)
+
+Eight practical steps to transition a fragile vibe-coded project into a predictable, resilient, and observable software system. Covers system dependencies, explicit business workflows, security boundaries, error recovery, defensive validation, and observability.
+
 ## How to use the cheatsheet
 
 1. Open the guide or series relevant to your change.

--- a/AI Engineering Cheatsheet/VIBECODING_TO_VERIFIED_ENGINEERING_GUIDE.md
+++ b/AI Engineering Cheatsheet/VIBECODING_TO_VERIFIED_ENGINEERING_GUIDE.md
@@ -1,0 +1,82 @@
+# From Vibecoding to Verified Engineering
+
+> Vibecoding is fast for prototypes, but fatal for production. Verified engineering transforms LLM-generated enthusiasm into predictable, resilient, and observable software systems.
+
+"Vibecoding" relies on large language models (LLMs) to write applications rapidly, often driven by high-level natural language prompts. While this accelerates initial creation, it frequently produces code that works on the "happy path" but lacks the architectural rigor required for production environments.
+
+This guide outlines eight practical steps to transition a project from a fragile vibe-coded experiment into verified engineering.
+
+## 1. Trace the Unseen Connections
+
+**Vibecoding symptom:** Files are generated in isolation. Changing a data model breaks an unrelated dashboard because dependencies are implicit, and the developer lacks a mental model of the entire system.
+
+**Verified engineering:** Extract a complete, connected code map. 
+- Map which functions, external API calls, and state changes interact before making modifications.
+- Do not rely on "the LLM remembers the context." Use static analysis tools to verify import paths, call graphs, and coupling.
+- Group related code into cohesive modules with explicit boundaries.
+
+## 2. Document Explicit Business Workflows
+
+**Vibecoding symptom:** The application works if users provide perfect inputs, but partial failures, retries, concurrency issues, and edge cases are unhandled or cause data corruption.
+
+**Verified engineering:** Elevate code paths to business workflows.
+- Define explicit entry points, decisions, material effects, and recovery boundaries.
+- Map state transitions explicitly (e.g., `PENDING` -> `AUTHORIZED` -> `CAPTURED`) rather than relying on assumed or unconstrained string values.
+- Review every workflow against a standardized scenario list (like the Core 20 Scenarios).
+
+## 3. Harden the Authorization Boundary
+
+**Vibecoding symptom:** Security is assumed because "the prompt says not to expose sensitive data" or the LLM didn't generate any obvious vulnerabilities in its first pass.
+
+**Verified engineering:** Implement deterministic policy enforcement.
+- Do not trust the LLM to enforce access control.
+- Validate every request token, implement role-based access control (RBAC), and isolate tenant data deterministically in code or via a policy engine.
+- Assume every input—whether from a user, a retrieved document, or an LLM response—is potentially hostile.
+
+## 4. Engineer for Recoverable Failures
+
+**Vibecoding symptom:** If an external system times out or an LLM returns malformed JSON, the process crashes, leaving databases in an inconsistent or locked state.
+
+**Verified engineering:** Anticipate and absorb failure.
+- Implement idempotency keys for all state-mutating operations.
+- Build robust retry mechanisms with exponential backoff and jitter for transient failures.
+- Introduce reconciliation jobs or manual repair procedures for external state that falls out of sync.
+
+## 5. Implement Defensive Data Validation
+
+**Vibecoding symptom:** The codebase assumes the LLM will always output valid JSON that strictly adheres to the requested schema.
+
+**Verified engineering:** Trust, but verify deterministically.
+- Use strict schema validation libraries (e.g., Pydantic in Python, Zod in TypeScript) at every system boundary.
+- If a high-impact decision (like processing a payment or deleting a resource) relies on parsed LLM output, fail closed if validation fails.
+- Strip or escape outputs before rendering them to prevent injection attacks.
+
+## 6. Meaningful Error Handling and Logging
+
+**Vibecoding symptom:** The code features generic `try-catch` blocks that swallow errors and print "Something went wrong," making debugging in production nearly impossible.
+
+**Verified engineering:** Differentiate and categorize failures.
+- Distinguish between protocol errors (network timeout), validation errors (bad input), business logic failures (insufficient funds), and dependency outages (database down).
+- Use semantic error logging. Ensure logs contain actionable context without leaking Personally Identifiable Information (PII) or secrets.
+
+## 7. Evidence-Based Testing and Evaluations
+
+**Vibecoding symptom:** Testing consists of running a prompt three times, observing correct outputs, and deploying to production.
+
+**Verified engineering:** Prove runtime quality deterministically.
+- Write deterministic unit and integration tests for core business logic, independent of the LLM.
+- Build automated evaluations (evals) for LLM behavior over time using a known dataset of edge cases, past failures, and adversarial inputs.
+- Compare prompts, models, and tools against a stable baseline to prevent silent regressions.
+
+## 8. Measurable Observability
+
+**Vibecoding symptom:** Monitoring means looking at terminal logs or occasionally checking API provider billing costs.
+
+**Verified engineering:** Understand the system dynamically.
+- Correlate traces, metrics, and logs with specific run, user, and task identifiers.
+- Track business metrics (e.g., workflow completion rates) alongside technical metrics (e.g., latency, token usage).
+- Ensure that for any failed production run, an engineer can trace the exact sequence of events, inputs, and state changes end-to-end.
+
+---
+
+> **The Verification Checklist:** Before shipping a vibe-coded feature to production, ask: "If the LLM generates a perfectly incorrect response, what deterministic system catches the error before it affects the user?"


### PR DESCRIPTION
Added a new comprehensive guide to the AI Engineering Cheatsheet: `VIBECODING_TO_VERIFIED_ENGINEERING_GUIDE.md`. 

This directly aligns with the project's core mission to transform fragile vibe-coded experiments into predictable, verified software engineering. It covers 8 actionable steps including mapping implicit connections, explicit workflows, defensive validation, and observability.

I have also updated the `AI Engineering Cheatsheet/README.md` to link to this new guide. Checked that the Markdown renders correctly.

