### PR TITLE
[Improvement] Add password-reset-and-account-recovery workflow pack

### DIFF
--- a/prebuilt-workflow-paths/README.md
+++ b/prebuilt-workflow-paths/README.md
@@ -69,6 +69,7 @@ No installation, generator, schema, or build step is required. Every workflow is
 | [Fraud-risk Scoring, Step-up, Block, and Case Creation](fraud-risk-check-step-up-block-and-investigation/) | evaluates protected actions and may allow, challenge, hold, block, or investigate them |
 | [Right-to-erasure and Account-data Deletion](account-data-deletion-and-right-to-erasure/) | verifies and executes deletion or anonymization requests across data stores and processors |
 | [Scheduled Job Execution, Checkpoint, Retry, and Recovery](scheduled-job-execution-retry-and-recovery/) | runs scheduled work with leases, bounded input windows, checkpoints, retries, and repair |
+| [Password Reset and Account Recovery](password-reset-and-account-recovery/) | issues a time-limited single-use token, updates the credential, and invalidates all active sessions |
 
 The navigation categories are only for discovery. Each workflow has its own clear start, end, stages, effects, permissions, and recovery boundary.
 
@@ -129,10 +130,10 @@ Read the [repository contribution guide](../.github/CONTRIBUTING.md) before prop
 
 ## Collection summary
 
-- 18 independently usable business workflow packs
-- 234 workflow-specific Markdown files
-- 360 compact core scenarios
-- 360 complete Given/When/Expect scenario descriptions
-- 90 portable task skills
+- 19 independently usable business workflow packs
+- 247 workflow-specific Markdown files
+- 380 compact core scenarios
+- 380 complete Given/When/Expect scenario descriptions
+- 95 portable task skills
 
 These packs are starting points for application-specific analysis. Product rules, laws, provider contracts, data-retention requirements, and operational limits still need to be adapted to the repository being reviewed.

--- a/prebuilt-workflow-paths/password-reset-and-account-recovery/CORE_20_SCENARIOS.md
+++ b/prebuilt-workflow-paths/password-reset-and-account-recovery/CORE_20_SCENARIOS.md
@@ -1,0 +1,26 @@
+# Core 20 Scenarios
+
+| # | Scenario | Must not happen |
+|---:|---|---|
+| 1 | Valid email submits reset request and receives token link | Reset link is not delivered or token is not recorded |
+| 2 | Unregistered email submits reset request | Response reveals whether the email is registered |
+| 3 | Valid token used within expiry window | Credential is updated without consuming the token |
+| 4 | Expired token submitted for reset | Credential is updated using an expired token |
+| 5 | Already-consumed token is replayed | Credential is updated a second time with the same token |
+| 6 | New reset request arrives while prior token is still valid | Both tokens remain valid simultaneously |
+| 7 | User sets a new password meeting all policy rules | Credential update proceeds without policy verification |
+| 8 | New password fails complexity or length policy | Non-compliant credential replaces the current one |
+| 9 | New password is identical to the current password | Reused credential is silently accepted when policy prohibits it |
+| 10 | Credential update succeeds | Active sessions remain valid after the credential changes |
+| 11 | Two concurrent reset requests arrive for the same account | Both tokens are issued and both remain valid |
+| 12 | Token format is tampered or structurally invalid | Malformed input reaches the credential store |
+| 13 | Rate limit is exceeded for reset requests | Unlimited reset emails are sent from one source |
+| 14 | Reset request arrives for a locked or suspended account | Token is issued and credential is changed for a restricted account |
+| 15 | Account is deleted between request submission and token use | Deleted account credential is updated |
+| 16 | Credential update succeeds but session invalidation response is lost | Retry creates a duplicate credential update |
+| 17 | Token link is opened after the account email address has changed | Token validates against the new email owner |
+| 18 | Reset request response time differs between registered and unregistered emails | Timing difference reveals account existence |
+| 19 | Successful credential update is not followed by a confirmation notification | User is unaware that their credential was changed |
+| 20 | Admin triggers a forced password reset for a user | User can authenticate with the old credential before completing the forced reset |
+
+Full details are in [TESTING_GUIDE.md](TESTING_GUIDE.md).

--- a/prebuilt-workflow-paths/password-reset-and-account-recovery/ENGINEERING_GUIDE.md
+++ b/prebuilt-workflow-paths/password-reset-and-account-recovery/ENGINEERING_GUIDE.md
@@ -1,0 +1,33 @@
+# Engineering Guide
+
+## Trace the implementation
+1. Reset request submission endpoint, email lookup, account state check, and rate-limit enforcement
+2. Token generation, entropy source, hashing strategy, storage, and expiry assignment
+3. Prior token revocation when a new request is accepted for the same account
+4. Email dispatch: queuing, link construction, token embedding, and delivery handoff
+5. Token validation endpoint: lookup, hash comparison, expiry check, and single-use flag
+6. Password policy enforcement: length, complexity, history, and same-as-current check
+7. Credential update: atomic write, password hash replacement, and update timestamp
+8. Session invalidation: scope selection, store update, refresh and access token revocation
+9. Audit record creation at each stage: request, token issue, validation, credential update, and session invalidation
+10. Account enumeration protection: constant-time lookup and uniform response regardless of email existence
+
+## Rules the code should protect
+- A reset response must not differ by content or timing based on whether the email exists
+- Tokens must be stored as hashes; plaintext tokens must not persist after issue
+- A token must transition to consumed in the same transaction as the credential update
+- A new reset request must revoke any prior unconsumed token for the same account
+- Credential updates must not proceed without passing all password policy checks
+- Session invalidation must cover all active sessions, not only the current one
+- Partial failure in session invalidation must leave a visible, auditable, and repairable state
+- Rate limiting must apply per email address and per source IP independently
+
+## Build or change safely
+1. Confirm token expiry window, revocation policy, and session scope with product before implementation
+2. Use a cryptographically secure random source for token generation and time-safe comparison for validation
+3. Wrap the token consumption and credential update in one atomic write or implement compensating recovery
+4. Apply constant-time string comparison to prevent timing-based account enumeration
+5. Test rate limiting at the boundary: the first blocked request and the first allowed request after reset
+6. Verify session invalidation covers refresh tokens, access tokens, and any persistent device tokens
+7. Confirm audit records are written even when the credential update fails
+8. Add the core 20 tests before shipping any change to this workflow

--- a/prebuilt-workflow-paths/password-reset-and-account-recovery/IMPLEMENT_WORKFLOW_SKILL.md
+++ b/prebuilt-workflow-paths/password-reset-and-account-recovery/IMPLEMENT_WORKFLOW_SKILL.md
@@ -1,0 +1,45 @@
+---
+name: "Implement Password Reset and Account Recovery"
+description: "Guides the implementation or modification of the password reset and account recovery workflow while preserving token safety, single-use enforcement, session invalidation, enumeration protection, rate limiting, and audit completeness."
+---
+
+# Implement Workflow — Password Reset and Account Recovery
+
+You are implementing or modifying the password reset and account recovery workflow.
+
+## Your task
+
+Using the connected code context and any available specification, implement the change described while preserving all existing safeguards. Require file and symbol evidence for every conclusion about what the current code does.
+
+## Implementation sequence
+
+**1. Reset request handler**
+Implement account lookup using constant-time or uniform-delay logic to prevent timing-based enumeration. Apply rate limiting before the account lookup to avoid leaking account existence through rate-limit bypass. Return an identical response regardless of whether the account exists.
+
+**2. Token generation**
+Use a cryptographically secure random source with at least 128 bits of entropy. Store only the hash of the token. Assign an expiry timestamp at generation. Revoke any prior unconsumed token for the same account before inserting the new one.
+
+**3. Email dispatch**
+Construct the reset link using a path that does not embed the email address. Queue the email after the token is stored. Handle delivery failure without exposing token details in error logs.
+
+**4. Token validation**
+Use constant-time comparison when matching the submitted token against the stored hash. Enforce expiry before checking validity. Consume the token in the same transaction as the credential write, not before.
+
+**5. Password policy enforcement**
+Validate length, complexity, and history requirements before attempting the credential write. Reject passwords identical to the current credential if policy requires it. Return a specific policy violation message without revealing the current credential.
+
+**6. Credential update**
+Write the new password hash in a transaction that includes token consumption. Do not commit the credential update if policy validation has not passed.
+
+**7. Session invalidation**
+Invalidate all active sessions, refresh tokens, and access tokens after the credential update is committed. Log any invalidation failure as a recoverable, auditable state. Do not block the credential update on session invalidation failure.
+
+**8. Audit record**
+Write an audit record at each stage: request received, token issued, validation attempted, credential updated, session invalidation outcome, and notification dispatched. Do not include the plaintext token, new password, or old password hash in any log entry.
+
+## Safety checks before shipping
+- Verify that the response body and processing time are identical for registered and unregistered emails
+- Verify that a consumed token cannot be replayed
+- Verify that an expired token is rejected
+- Verify that session invalidation is called after every successful credential update
+- Confirm that all 20 core scenarios have a corresponding test

--- a/prebuilt-workflow-paths/password-reset-and-account-recovery/PATHS_AND_EDGE_CASES.md
+++ b/prebuilt-workflow-paths/password-reset-and-account-recovery/PATHS_AND_EDGE_CASES.md
@@ -1,0 +1,34 @@
+# Paths and Edge Cases
+
+## Supported paths
+- Active account submits reset request and receives token link within the configured window
+- User opens token link and sets a new password that meets all policy rules
+- Credential is updated, token is consumed, and all sessions are invalidated in one operation
+- Admin triggers a forced reset and the user must complete it before accessing the application
+- User requests a second reset before the first token expires; the prior token is revoked
+
+## Denied paths
+- Unregistered email submits a reset request: safe identical response, no token issued
+- Expired token submitted: request rejected, credential unchanged
+- Consumed token replayed: request rejected, credential unchanged
+- Non-compliant password submitted: request rejected, credential unchanged
+- Reset request for locked or suspended account: request rejected, no token issued
+- Rate limit exceeded: request rejected, no token issued
+- Tampered or structurally invalid token: request rejected at format check
+
+## Timing and expiry boundaries
+- Token submitted exactly at the expiry timestamp: implementation must define inclusive or exclusive boundary and apply it consistently
+- Reset request submitted immediately before and immediately after the rate limit window resets
+- Session invalidation called immediately after credential update: invalidation must not race with a concurrent authentication using the old credential
+
+## Concurrency paths
+- Two reset requests arrive simultaneously for the same account: only the later token remains valid
+- Reset request and a concurrent login with the old credential overlap: the login must fail after the credential update is committed
+- Session invalidation and a concurrent token refresh overlap: the refresh must fail if invalidation is committed first
+
+## Unusual paths
+- User completes reset but does not sign in with the new credential before the session invalidation window closes
+- Account email address changes between reset request and token use
+- Email provider returns a delivery failure after the token has been issued
+- User opens the reset link from a forwarded or shared email
+- Multiple reset emails are forwarded to a shared inbox and a non-account-holder uses one

--- a/prebuilt-workflow-paths/password-reset-and-account-recovery/PERMISSION_AND_ABUSE_GUIDE.md
+++ b/prebuilt-workflow-paths/password-reset-and-account-recovery/PERMISSION_AND_ABUSE_GUIDE.md
@@ -1,0 +1,36 @@
+# Permission and Abuse Guide
+
+## Authorization boundaries
+- Only the account holder who receives the reset email link may complete the credential update
+- A reset token is bound to one account and must not validate against any other account
+- Admin-triggered forced resets require an authenticated admin role with an explicit permission to initiate resets for other accounts
+- The reset endpoint must not accept authentication credentials as a substitute for a valid token
+
+## Misuse paths
+
+### Account enumeration
+An attacker submits reset requests for guessed email addresses and observes response content or timing to determine which accounts exist. The response body, status code, and processing time must be identical for registered and unregistered addresses.
+
+### Token guessing
+An attacker generates tokens matching the reset format and submits them. Tokens must have sufficient entropy (minimum 128 bits from a cryptographically secure source) to make brute force infeasible within the expiry window.
+
+### Link interception and replay
+An attacker intercepts a reset link from email logs, forwarded messages, or browser history and attempts to use it after the legitimate user has already completed the reset. The single-use flag and session invalidation prevent reuse.
+
+### Reset flooding
+An attacker submits continuous reset requests for a target account to fill the user's inbox, block legitimate resets, or exhaust email delivery quotas. Rate limiting per email address and per source IP must bound the number of tokens issued and emails sent.
+
+### Cross-account token submission
+An attacker obtains a token issued for their own account and submits it with another account's identifier. The token must be validated against the account it was issued for and rejected for any other account.
+
+### Forced reset bypass
+An attacker with access to a session from before a forced reset was triggered attempts to continue using the session. The forced reset flag must be checked on every authenticated request until the reset is completed.
+
+## Tenant isolation
+- In multi-tenant systems, a reset token issued for an account in one tenant must not validate for an account in another tenant
+- Tenant context must be included in the token binding and verified during validation
+
+## Protected data
+- Reset tokens must be stored as hashes; the plaintext token must not be logged, persisted, or exposed in any response
+- The account email address must not appear in reset link URLs in a way that allows enumeration
+- Audit records must not include the plaintext token, the new password, or the old password hash

--- a/prebuilt-workflow-paths/password-reset-and-account-recovery/PRODUCT_AND_BUSINESS_GUIDE.md
+++ b/prebuilt-workflow-paths/password-reset-and-account-recovery/PRODUCT_AND_BUSINESS_GUIDE.md
@@ -1,0 +1,88 @@
+# Product and Business Guide
+
+## Boundary
+Starts when a user submits a password reset request with a registered email address. Ends when the user authenticates successfully with the new credential, the reset token is consumed, all prior sessions are invalidated, and the account record reflects the updated credential.
+
+## People and systems
+- User or account holder requesting the reset
+- Authentication and identity service
+- Token store and session store
+- Email and notification service
+- Account and user profile service
+- Operations, support, and security teams
+
+## Things created or changed
+- Password reset request and submission timestamp
+- Reset token, token hash, expiry time, and single-use flag
+- Reset email containing the token link and expiry notice
+- New credential and password hash replacing the previous one
+- Active sessions, refresh tokens, and access tokens invalidated after credential change
+- Audit record of reset request, token issue, credential update, and session invalidation
+
+## Stages
+- Reset request: absent → submitted → validated, rejected, or rate-limited
+- Token: absent → issued → delivered, consumed, expired, or revoked
+- Email: absent → queued → delivered or failed
+- Credential: current → pending update → updated or unchanged
+- Sessions: active → invalidating → fully invalidated or partially active
+
+## Product decisions
+- Which email addresses and account states may initiate a reset
+- Token format, length, entropy, and storage strategy (hash vs plaintext)
+- Token expiry window and whether a new request revokes the prior token
+- Safe response policy when the submitted email is not registered
+- Password complexity, minimum length, history, and reuse rules
+- Whether the new password may match the current password
+- Session invalidation scope: all devices, all except current, or configurable
+- Rate limiting strategy: per email, per IP, per account, and lockout behaviour
+- Notification to the user after a successful credential change
+- Admin-triggered forced reset and its interaction with the standard flow
+- Audit retention and privacy rules for reset events
+
+## Happy paths
+- A registered user submits their email, receives a valid reset link, sets a new password that meets policy, and signs in with the new credential
+- All active sessions are invalidated after the credential is updated
+- The consumed token cannot be reused
+
+## Negative paths
+- The submitted email is not associated with any account
+- The token has expired before it is used
+- The token has already been consumed
+- The new password does not meet complexity or reuse policy
+- The account is locked, suspended, or pending deletion at the time of the request or use
+- The rate limit for reset requests has been exceeded
+
+## Edge cases
+- Two concurrent reset requests arrive for the same account
+- The user uses a previously issued token after a newer one has been requested
+- The reset email is delivered but the link is opened after the token has expired
+- The credential update succeeds but the session invalidation response is lost
+- The account is deleted between request submission and token use
+- A reset request arrives for an account whose email address has changed since the link was generated
+- The user sets the same password as the current one when policy should prevent it
+
+## Acceptance criteria
+1. A reset request for an unregistered email must return a safe, identical response to a valid one
+2. Tokens must be single-use: a consumed token must not update the credential a second time
+3. Tokens must expire: an expired token must not update the credential
+4. A new token request must revoke any prior unconsumed token for the same account
+5. The new credential must meet all password policy rules before the update is committed
+6. All active sessions must be invalidated after a successful credential update
+7. The credential update and session invalidation must be atomic or leave a recoverable, auditable state on partial failure
+8. Reset requests must be rate-limited to prevent enumeration and abuse
+9. The reset audit record must capture request time, token issue, credential update, and session invalidation outcome
+10. No information about account existence must be revealed through response timing or content differences
+
+## Business risks
+| Risk | Business consequence |
+|---|---|
+| Account enumeration via reset response | Attacker discovers which email addresses are registered |
+| Token not single-use | Attacker who intercepts a used link can change the credential again |
+| No token expiry | Indefinitely valid links expose accounts to delayed takeover |
+| Sessions not invalidated after reset | Attacker who holds an active session retains access after the user resets |
+| Credential update without policy check | Weak or previously breached password replaces the current one |
+| New token does not revoke previous token | Multiple valid reset links exist simultaneously, increasing exposure window |
+| Timing difference reveals account existence | Statistical analysis of response times exposes registered accounts |
+| No rate limiting on reset requests | Attacker floods the system with reset emails, causing denial of service |
+| Partial session invalidation not surfaced | User believes they are secure while attacker retains one active session |
+| Audit record missing | Security investigation cannot reconstruct the reset sequence |

--- a/prebuilt-workflow-paths/password-reset-and-account-recovery/README.md
+++ b/prebuilt-workflow-paths/password-reset-and-account-recovery/README.md
@@ -1,0 +1,30 @@
+# Password Reset and Account Recovery
+
+Starts when a user submits a password reset request with a registered email address. Ends when the user authenticates successfully with the new credential, the reset token is consumed, all prior sessions are invalidated, and the account record reflects the updated credential.
+
+| Task | File |
+|---|---|
+| Product and business | [PRODUCT_AND_BUSINESS_GUIDE.md](PRODUCT_AND_BUSINESS_GUIDE.md) |
+| Engineering | [ENGINEERING_GUIDE.md](ENGINEERING_GUIDE.md) |
+| Testing | [TESTING_GUIDE.md](TESTING_GUIDE.md) |
+| Core 20 | [CORE_20_SCENARIOS.md](CORE_20_SCENARIOS.md) |
+| Paths and edge cases | [PATHS_AND_EDGE_CASES.md](PATHS_AND_EDGE_CASES.md) |
+| Permissions and misuse | [PERMISSION_AND_ABUSE_GUIDE.md](PERMISSION_AND_ABUSE_GUIDE.md) |
+| Retry and recovery | [RETRY_AND_RECOVERY_GUIDE.md](RETRY_AND_RECOVERY_GUIDE.md) |
+
+## Included
+- reset request submission and email validation
+- token generation, delivery, expiry, single-use enforcement, and revocation
+- credential update, password policy validation, and audit record
+- active session invalidation after credential change
+- account enumeration protection and rate limiting
+- admin-triggered forced reset path
+
+## Excluded
+- user registration and initial password creation
+- multi-factor authentication and step-up verification
+- account deletion and right-to-erasure
+- transactional notification delivery mechanics
+- fraud-risk scoring and account lock investigation
+
+The five `*_SKILL.md` files are self-contained.

--- a/prebuilt-workflow-paths/password-reset-and-account-recovery/RETRY_AND_RECOVERY_GUIDE.md
+++ b/prebuilt-workflow-paths/password-reset-and-account-recovery/RETRY_AND_RECOVERY_GUIDE.md
@@ -1,0 +1,29 @@
+# Retry and Recovery Guide
+
+## Partial failures and their recovery states
+
+### Token issued but email not delivered
+The token exists in the store but the email was never received. The user may request a new reset, which revokes the prior token and issues a new one. The system must not leave an orphaned, unreachable token that remains valid indefinitely.
+
+### Credential update succeeds but session invalidation fails
+The new credential is committed but one or more sessions remain active. The system must record a session invalidation failure in the audit log and retry invalidation asynchronously. Any retry must be idempotent and must not trigger a second credential update. Operations must be able to trigger a manual forced-logout for all sessions on the account.
+
+### Session invalidation succeeds but confirmation notification fails
+Sessions are cleared but the user does not receive a confirmation email. The audit log must record the notification failure. The credential update is not rolled back. A retry of the notification is safe because it carries no credential information.
+
+### Credential update fails after token consumption
+If the token is marked consumed before the credential write is committed and the write then fails, the account is left with a consumed token and the old credential. The recovery path is to allow the user to request a new reset. The implementation must avoid consuming the token before the credential write is confirmed.
+
+## Idempotency rules
+- Submitting a valid unconsumed token a second time before it is consumed must be idempotent if the password submission is identical; the credential must not be updated twice
+- Retrying session invalidation after a lost response must produce the same invalidated state without affecting the credential
+- Retrying the confirmation notification must not send duplicate emails if the first delivery succeeded
+
+## Retry boundaries
+- The token validation and credential update must complete within one synchronous request; retrying this call with the same token after a timeout must be rejected if the token was already consumed
+- Session invalidation retries must be bounded; after a configured number of failures the account must be flagged for manual review
+
+## Manual repair
+- Operations must be able to revoke all active tokens for an account without changing the credential
+- Operations must be able to force-invalidate all sessions for an account independently of the reset flow
+- Operations must be able to mark an account as requiring a forced reset without knowing the current credential

--- a/prebuilt-workflow-paths/password-reset-and-account-recovery/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/password-reset-and-account-recovery/REVIEW_BUSINESS_RISK_SKILL.md
@@ -1,0 +1,50 @@
+---
+name: "Review Business Risk for Password Reset and Account Recovery"
+description: "Reviews the password reset and account recovery workflow for customer, security, revenue, and operational risks, including account takeover, session persistence after credential change, enumeration exposure, and partial recovery failures."
+---
+
+# Review Business Risk — Password Reset and Account Recovery
+
+You are reviewing the password reset and account recovery workflow for business risk.
+
+## Your task
+
+Using the connected code context and any available specification, identify risks that could harm customers, expose accounts to takeover, cause revenue loss, or create an unrecoverable operational state.
+
+## Risk categories to evaluate
+
+**Account takeover risks**
+- Is the token single-use? Can a consumed token be replayed?
+- Is token entropy sufficient to prevent brute force within the expiry window?
+- Are multiple valid tokens possible for the same account at the same time?
+- Is session invalidation guaranteed after a credential update?
+
+**Enumeration and privacy risks**
+- Does the response differ by content or timing based on whether the email is registered?
+- Are plaintext tokens written to logs, URLs, or error messages?
+- Does the reset link embed the email address in a way that allows account discovery?
+
+**Availability and abuse risks**
+- Can an attacker flood a user's inbox by submitting repeated reset requests?
+- Is rate limiting applied per email address and per source IP independently?
+- Can reset request flooding prevent a legitimate user from completing a reset?
+
+**Recovery and operational risks**
+- If session invalidation fails, is the failure visible and repairable by operations?
+- If the credential update succeeds but confirmation notification fails, is the user informed through another channel?
+- Can operations revoke all tokens and invalidate all sessions for an account without resetting the credential?
+
+**Forced reset risks**
+- If an admin forces a reset, can the user bypass it by using an existing session?
+- Is the forced reset flag checked on every authenticated request until the reset is complete?
+
+## For each risk found, state
+
+- What triggers the risk
+- What the code currently does or fails to do
+- The affected workflow stage
+- The potential business impact
+- What should change
+- How to verify the correction
+
+If no risk meets the evidence threshold, record a no-findings outcome with the scope reviewed and the evidence examined.

--- a/prebuilt-workflow-paths/password-reset-and-account-recovery/TESTING_GUIDE.md
+++ b/prebuilt-workflow-paths/password-reset-and-account-recovery/TESTING_GUIDE.md
@@ -1,0 +1,179 @@
+# Testing Guide
+
+## Scenario 1 — Valid email submits reset request and receives token link
+**Given** an active account exists with a registered email address  
+**When** the user submits a reset request with that email  
+**Expect** a reset token is generated, stored as a hash, and a link is delivered to that email within the expected window  
+**Must not happen** the reset link is not delivered or the token is not recorded in the token store  
+**Suggested test level** integration, end-to-end
+
+---
+
+## Scenario 2 — Unregistered email submits reset request
+**Given** no account exists for the submitted email address  
+**When** the user submits a reset request  
+**Expect** the response body, status code, and response time are identical to a successful request  
+**Must not happen** the response reveals whether the email is registered through content or timing  
+**Suggested test level** unit, integration, timing analysis
+
+---
+
+## Scenario 3 — Valid token used within expiry window
+**Given** a reset token has been issued and has not expired  
+**When** the user submits the token and a new compliant password  
+**Expect** the credential is updated, the token is marked consumed, and a success response is returned  
+**Must not happen** the credential is updated without the token being consumed in the same operation  
+**Suggested test level** unit, integration
+
+---
+
+## Scenario 4 — Expired token submitted for reset
+**Given** a reset token was issued and its expiry window has passed  
+**When** the user submits the expired token  
+**Expect** the request is rejected with a clear expiry message and the credential is unchanged  
+**Must not happen** the credential is updated using an expired token  
+**Suggested test level** unit, integration
+
+---
+
+## Scenario 5 — Already-consumed token is replayed
+**Given** a reset token has been used and the credential has been updated  
+**When** the same token is submitted again  
+**Expect** the request is rejected and the credential remains as updated in the prior step  
+**Must not happen** the credential is updated a second time with the same token  
+**Suggested test level** unit, integration
+
+---
+
+## Scenario 6 — New reset request arrives while prior token is still valid
+**Given** an unconsumed token exists for an account  
+**When** a new reset request is submitted for the same account  
+**Expect** the prior token is revoked and a new token is issued  
+**Must not happen** both tokens remain valid simultaneously  
+**Suggested test level** unit, integration
+
+---
+
+## Scenario 7 — User sets a new password meeting all policy rules
+**Given** the user holds a valid token  
+**When** the user submits a new password that satisfies length, complexity, and history requirements  
+**Expect** the credential is updated and the token is consumed  
+**Must not happen** the credential update proceeds without verifying all policy rules  
+**Suggested test level** unit, integration
+
+---
+
+## Scenario 8 — New password fails complexity or length policy
+**Given** the user holds a valid token  
+**When** the user submits a new password that does not meet policy requirements  
+**Expect** the request is rejected with a policy violation message and the credential is unchanged  
+**Must not happen** a non-compliant credential replaces the current one  
+**Suggested test level** unit, boundary
+
+---
+
+## Scenario 9 — New password is identical to the current password
+**Given** the user holds a valid token and password reuse is prohibited by policy  
+**When** the user submits a new password identical to the current credential  
+**Expect** the request is rejected with a reuse message and the credential is unchanged  
+**Must not happen** the reused credential is silently accepted  
+**Suggested test level** unit, integration
+
+---
+
+## Scenario 10 — Credential update succeeds
+**Given** the credential has been updated using a valid token  
+**When** the credential update is committed  
+**Expect** all active sessions, refresh tokens, and access tokens for the account are invalidated  
+**Must not happen** any active session remains valid after the credential changes  
+**Suggested test level** integration, end-to-end
+
+---
+
+## Scenario 11 — Two concurrent reset requests arrive for the same account
+**Given** two reset requests are submitted simultaneously for the same account  
+**When** both requests are processed  
+**Expect** only one token is valid after processing; the other is revoked or superseded  
+**Must not happen** both tokens are valid simultaneously  
+**Suggested test level** concurrency, integration
+
+---
+
+## Scenario 12 — Token format is tampered or structurally invalid
+**Given** a reset link has been altered or a token with an invalid format is submitted  
+**When** the token is validated  
+**Expect** the request is rejected at format validation before any store lookup  
+**Must not happen** a malformed token reaches the credential store or causes an unhandled error  
+**Suggested test level** unit, security
+
+---
+
+## Scenario 13 — Rate limit is exceeded for reset requests
+**Given** the rate limit threshold for reset requests has been reached for a given email or IP  
+**When** another reset request is submitted  
+**Expect** the request is rejected with a rate-limit response and no new token is issued  
+**Must not happen** unlimited reset emails are dispatched from a single source  
+**Suggested test level** integration, load
+
+---
+
+## Scenario 14 — Reset request arrives for a locked or suspended account
+**Given** the account is in a locked or suspended state  
+**When** a reset request is submitted for that account  
+**Expect** the request is rejected without issuing a token  
+**Must not happen** a token is issued and the credential is changed for a restricted account  
+**Suggested test level** unit, integration
+
+---
+
+## Scenario 15 — Account is deleted between request submission and token use
+**Given** a token was issued for an account that is subsequently deleted  
+**When** the token is submitted for credential update  
+**Expect** the request is rejected because the account no longer exists  
+**Must not happen** the deleted account credential is updated or a new credential record is created  
+**Suggested test level** integration
+
+---
+
+## Scenario 16 — Credential update succeeds but session invalidation response is lost
+**Given** the credential has been updated and a session invalidation call is retried  
+**When** the invalidation is retried after a lost response  
+**Expect** the retry is idempotent and does not produce a duplicate credential update  
+**Must not happen** the retry causes the credential to be overwritten or sessions to be partially invalidated  
+**Suggested test level** unit, recovery
+
+---
+
+## Scenario 17 — Token link is opened after the account email address has changed
+**Given** a token was issued to an email address that has since been changed on the account  
+**When** the original email link is submitted  
+**Expect** the token is rejected or the account owner is re-verified before credential update  
+**Must not happen** the token validates against the new email owner's account  
+**Suggested test level** integration, security
+
+---
+
+## Scenario 18 — Reset request response time differs between registered and unregistered emails
+**Given** the system receives reset requests for registered and unregistered emails  
+**When** response times are compared across both cases  
+**Expect** response times are statistically indistinguishable  
+**Must not happen** a measurable timing difference reveals whether an account exists  
+**Suggested test level** timing analysis, security
+
+---
+
+## Scenario 19 — Successful credential update is not followed by a confirmation notification
+**Given** the credential has been updated successfully  
+**When** the update is committed  
+**Expect** a confirmation notification is dispatched to the account email address  
+**Must not happen** the user receives no notification that their credential has changed  
+**Suggested test level** integration, end-to-end
+
+---
+
+## Scenario 20 — Admin triggers a forced password reset for a user
+**Given** an admin marks an account as requiring a forced password reset  
+**When** the user attempts to authenticate with their current credential  
+**Expect** the user is redirected to the reset flow and cannot access the application until the reset is complete  
+**Must not happen** the user authenticates successfully with the old credential before completing the forced reset  
+**Suggested test level** integration, end-to-end

--- a/prebuilt-workflow-paths/password-reset-and-account-recovery/TEST_WORKFLOW_SKILL.md
+++ b/prebuilt-workflow-paths/password-reset-and-account-recovery/TEST_WORKFLOW_SKILL.md
@@ -1,0 +1,52 @@
+---
+name: "Test Password Reset and Account Recovery"
+description: "Designs or reviews the complete test set for the password reset and account recovery workflow, covering the 20 core scenarios across unit, integration, concurrency, security, timing, and recovery test levels."
+---
+
+# Test Workflow — Password Reset and Account Recovery
+
+You are designing or reviewing the test set for the password reset and account recovery workflow.
+
+## Your task
+
+Using the connected code context and the 20 core scenarios, produce or evaluate tests that verify each scenario. Require specific route, function, fixture, and assertion details. Do not describe a test as passing unless the assertion is stated.
+
+## Test coverage required
+
+**Happy path tests**
+- Valid reset request for a registered email issues a token and dispatches an email
+- Valid token submitted within expiry updates the credential, consumes the token, and invalidates all sessions
+- Admin-triggered forced reset prevents authentication until the reset is completed
+
+**Negative and boundary tests**
+- Expired token is rejected and credential is unchanged
+- Consumed token replay is rejected
+- Non-compliant password is rejected and credential is unchanged
+- Password identical to current credential is rejected when policy prohibits reuse
+- Reset request for a locked or suspended account is rejected without issuing a token
+
+**Concurrency tests**
+- Two simultaneous reset requests for the same account produce only one valid token
+- Concurrent credential update and session refresh with the old credential: the refresh fails after the update commits
+
+**Security and timing tests**
+- Response body and status code are identical for registered and unregistered email addresses
+- Response time difference between registered and unregistered addresses is within the acceptable threshold
+- Tampered or invalid token format is rejected before any store lookup
+- Cross-account token submission is rejected
+
+**Recovery tests**
+- Session invalidation retry after a lost response is idempotent and does not update the credential again
+- Token issued but email not delivered: new reset request revokes the prior token and issues a new one
+
+**Audit tests**
+- Audit record is written for request, token issue, validation attempt, credential update, and session invalidation outcome
+- No plaintext token, new password, or old password hash appears in any audit or log entry
+
+## For each test, state
+- The scenario number from CORE_20_SCENARIOS.md
+- The test level: unit, integration, concurrency, security, timing, or recovery
+- The fixture or setup required
+- The action performed
+- The exact assertion that must pass
+- What must not appear in the result

--- a/prebuilt-workflow-paths/password-reset-and-account-recovery/UNDERSTAND_CODE_SKILL.md
+++ b/prebuilt-workflow-paths/password-reset-and-account-recovery/UNDERSTAND_CODE_SKILL.md
@@ -1,0 +1,41 @@
+---
+name: "Understand Code for Password Reset and Account Recovery"
+description: "Traces the password reset and account recovery workflow through a codebase using file and symbol evidence, identifying the reset request handler, token generation and storage, email dispatch, token validation, credential update, and session invalidation."
+---
+
+# Understand Code — Password Reset and Account Recovery
+
+You are tracing the password reset and account recovery workflow through a codebase.
+
+## Your task
+
+Using the connected code context provided, locate and describe each stage of this workflow with file names, function or method names, and line references where available. Do not state that a control exists unless file or symbol evidence supports it.
+
+## Trace sequence
+
+**1. Reset request handler**
+Find the route or endpoint that accepts the reset request. Identify how the submitted email is looked up, how account state is checked, and where the rate limit is enforced.
+
+**2. Token generation and storage**
+Find where the token is generated. Note the entropy source, token format, hashing approach, storage location, expiry assignment, and whether prior tokens for the same account are revoked.
+
+**3. Email dispatch**
+Find where the reset link is constructed and the email is queued or sent. Note whether delivery failure is handled and how the token is embedded in the link.
+
+**4. Token validation handler**
+Find the route or endpoint that accepts the token. Identify how the token is looked up, how expiry is checked, how the single-use flag is enforced, and how account binding is verified.
+
+**5. Credential update**
+Find where the new password is validated against policy and where the credential hash is written. Note whether the token is consumed in the same transaction as the credential write.
+
+**6. Session invalidation**
+Find where active sessions, refresh tokens, and access tokens are invalidated. Note the scope, whether failure is handled, and whether the invalidation is retried.
+
+**7. Audit record**
+Find where reset events are logged. Note which stages are recorded and whether plaintext tokens or passwords appear in any log call.
+
+## For each stage, state
+- The file path and function or method name
+- What the code does at that stage
+- Any missing control, unexpected behaviour, or deviation from the expected workflow
+- Any stage that could not be located in the provided context

--- a/prebuilt-workflow-paths/password-reset-and-account-recovery/WRITE_PRODUCT_SPEC_SKILL.md
+++ b/prebuilt-workflow-paths/password-reset-and-account-recovery/WRITE_PRODUCT_SPEC_SKILL.md
@@ -1,0 +1,45 @@
+---
+name: "Write Product Spec for Password Reset and Account Recovery"
+description: "Writes or reviews a product specification for the password reset and account recovery workflow, covering token policy, password rules, session invalidation scope, enumeration protection, rate limiting, admin-triggered resets, and acceptance criteria."
+---
+
+# Write Product Spec — Password Reset and Account Recovery
+
+You are writing or reviewing a product specification for the password reset and account recovery workflow.
+
+## Your task
+
+Using the context provided, produce or evaluate a specification that covers the following decisions and requirements.
+
+## Required sections
+
+**Scope and trigger**
+State the exact event that starts this workflow and the authoritative outcomes that end it. Distinguish this workflow from user registration, account deletion, and multi-factor authentication.
+
+**Token policy**
+Specify token expiry window, entropy requirements, storage strategy, single-use enforcement, and the behaviour when a new request arrives before the prior token is consumed.
+
+**Password rules**
+Specify minimum length, complexity requirements, history depth, and the policy for submitting a password identical to the current credential.
+
+**Session invalidation scope**
+State which sessions, refresh tokens, and access tokens are invalidated after a successful credential update and whether exceptions apply for the current device.
+
+**Account enumeration protection**
+Describe how the workflow ensures that response content and timing reveal nothing about whether the submitted email is registered.
+
+**Rate limiting**
+Specify the limit thresholds per email address and per source IP, the lockout duration, and the behaviour when the limit is reached.
+
+**Admin-triggered forced reset**
+Describe the conditions under which an admin may force a reset, what the user experiences, and which authentication actions are blocked until the reset is complete.
+
+**Notifications**
+Specify which messages are sent at request time and after successful credential update, and what happens when delivery fails.
+
+**Acceptance criteria**
+List the verifiable conditions that confirm the workflow is correctly implemented, covering token safety, session invalidation, enumeration protection, and audit completeness.
+
+## Evidence to collect
+
+When reviewing an existing specification, verify that each section above is present and unambiguous. Note any missing policy decision, any acceptance criterion that cannot be verified, and any scope overlap with adjacent workflows.


### PR DESCRIPTION
## Problem and scope
The prebuilt-workflow-paths collection covers payments, bookings, fraud,
and RAG but does not include a workflow pack for password reset and account
recovery — one of the most security-critical flows in any user-facing application.

## What changed
Added password-reset-and-account-recovery (13 files, MECE structure):
- Exactly 20 distinct core scenarios each with Must not happen
- Covers token safety, enumeration protection, session invalidation,
  rate limiting, concurrency, partial failure, and forced reset paths
- All 5 LLM skill files include valid name and description frontmatter
- prebuilt-workflow-paths/README.md updated with the new pack entry

## Verification
- [x] python -m black --config .github/quality/pyproject.toml --check .github/quality/tests
- [x] python -m flake8 --config .github/quality/.flake8 .github/quality/tests
- [x] python -m pytest -c .github/quality/pyproject.toml .github/quality/tests
      Result: 630 passed in 7.69s

## Remaining limitations
None known.
