### PR TITLE
Add Payment Dispute and Chargeback Resolution workflow pack

### DIFF
--- a/prebuilt-workflow-paths/README.md
+++ b/prebuilt-workflow-paths/README.md
@@ -41,6 +41,7 @@ No installation, generator, schema, or build step is required. Every workflow is
 | Workflow | Use it when your application… |
 |---|---|
 | [Checkout Payment Authorization and Capture](checkout-payment-authorization-and-capture/) | authorizes and captures payment while coordinating checkout and order state |
+| [Payment Dispute and Chargeback Resolution](payment-dispute-and-chargeback-resolution/) | handles cardholder or network disputes raised against a previously captured payment through evidence, representment, and final settlement |
 | [Subscription Renewal, Cancellation, and Entitlement Release](subscription-renewal-cancellation-and-access-removal/) | renews subscriptions, handles cancellation, and grants or removes access |
 | [Order Placement and Confirmation](order-placement-and-confirmation/) | validates a cart, creates an order, and confirms acceptance to the customer |
 | [Inventory Reservation, Release, and Expiry](inventory-reservation-release-and-expiry/) | temporarily reserves scarce inventory and later commits, releases, or expires it |
@@ -129,10 +130,10 @@ Read the [repository contribution guide](../.github/CONTRIBUTING.md) before prop
 
 ## Collection summary
 
-- 18 independently usable business workflow packs
-- 234 workflow-specific Markdown files
-- 360 compact core scenarios
-- 360 complete Given/When/Expect scenario descriptions
-- 90 portable task skills
+- 19 independently usable business workflow packs
+- 247 workflow-specific Markdown files
+- 380 compact core scenarios
+- 380 complete Given/When/Expect scenario descriptions
+- 95 portable task skills
 
 These packs are starting points for application-specific analysis. Product rules, laws, provider contracts, data-retention requirements, and operational limits still need to be adapted to the repository being reviewed.

--- a/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/CORE_20_SCENARIOS.md
+++ b/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/CORE_20_SCENARIOS.md
@@ -1,0 +1,26 @@
+# Core 20 Scenarios
+
+| # | Scenario | Must not happen |
+|---:|---|---|
+| 1 | Valid dispute opens against a captured payment | A case opens against a payment that was never captured or does not exist |
+| 2 | Complete evidence is submitted before the deadline | Incomplete or wrong evidence is recorded as a complete submission |
+| 3 | Low-value dispute is auto-accepted by policy | The case is contested past the cost-to-fight threshold without approval |
+| 4 | Authenticated transaction wins on liability shift | Liability shift is ignored and the merchant absorbs an avoidable loss |
+| 5 | Required dispute fields are missing | A guessed or unlinked case is created |
+| 6 | Dispute amount or currency mismatches the payment | The mismatch is silently reconciled instead of flagged |
+| 7 | Actor without dispute-team access submits evidence | An unauthorized actor modifies or submits case evidence |
+| 8 | Evidence deadline is reached at a timezone boundary | Clock differences extend or shorten the window unpredictably |
+| 9 | Two dispute webhooks arrive together for one case | The provisional debit is applied twice |
+| 10 | Provider retries the dispute-opened notification | A duplicate case is created for one chargeback |
+| 11 | Representment response from the network is lost | Resubmission creates a second representment instead of resuming the same case |
+| 12 | Case is escalated to pre-arbitration after resolution | The case is treated as final and closed prematurely |
+| 13 | Merchant chargeback ratio crosses the risk threshold | Risk-program escalation is not triggered |
+| 14 | Cardholder withdraws the dispute after representment | The case stays open or funds are not reinstated |
+| 15 | Provisional debit succeeds but the ledger write fails | A second debit is applied blindly on retry |
+| 16 | Dispute references another tenant's payment | Identifiers cross the tenant boundary into another merchant's case |
+| 17 | Resolution arrives after the order was already refunded | The ledger reverses the same funds twice |
+| 18 | Evidence bundle contains cardholder PAN or secrets | Sensitive data enters logs or unauthorized storage |
+| 19 | Final network outcome arrives after internal tracking expired | Stale internal state contradicts the authoritative network outcome |
+| 20 | Case resolves but the order or customer record update fails | The ledger, order, and customer outcome show contradictory states |
+
+Full details are in [TESTING_GUIDE.md](TESTING_GUIDE.md).

--- a/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/ENGINEERING_GUIDE.md
+++ b/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/ENGINEERING_GUIDE.md
@@ -1,0 +1,31 @@
+# Engineering Guide
+
+## Trace the implementation
+1. Dispute-webhook, manual-report, evidence-submission, and case-status entry points
+2. Actor, account, tenant, and case ownership checks
+3. Payment and order lookup used to bind a new case
+4. Case model, reason code, deadline, idempotency, and state-machine controls
+5. Evidence-bundle storage, representment drafting, and submission paths
+6. Provisional debit or credit, reserve adjustment, and ledger posting
+7. Liability-shift, auto-accept, and auto-contest policy evaluation
+8. Chargeback-ratio aggregation and risk-program status updates
+9. Audit, privacy, monitoring, support tools, and tests
+
+## Rules the code should protect
+- One chargeback notification must not open more than one case
+- A case must bind the intended payer, merchant, order, tenant, and payment
+- Provisional debit or credit must apply exactly once per case
+- Evidence deadlines must be enforced from the authoritative reason-code table
+- Case, ledger, order, and customer records must converge on one outcome
+- Liability-shift and auto-accept policy must not bypass required manual review
+- Chargeback-ratio status must reflect confirmed outcomes only
+- Cardholder data and evidence must remain protected and access-scoped
+
+## Build or change safely
+1. Confirm product decisions before relying on framework or provider defaults.
+2. Follow existing authorization, financial-state, storage, logging, monitoring, and test conventions.
+3. Bind every action to the authoritative actor, case, payment, order, tenant, and state.
+4. Enforce permission, current-state, uniqueness, ordering, and deadline rules at the write.
+5. Make retries and replays safe after partial failure and lost responses.
+6. Keep ledger, order, and risk-program inconsistency visible and repairable.
+7. Add the core 20 tests.

--- a/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/IMPLEMENT_WORKFLOW_SKILL.md
+++ b/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/IMPLEMENT_WORKFLOW_SKILL.md
@@ -1,0 +1,30 @@
+---
+name: implement-dispute-chargeback
+description: Implement or modify Payment Dispute and Chargeback Resolution. Use when adding or changing intake, linkage, evidence, deadline, ledger effects, escalation, liability-shift policy, recovery, or tests.
+---
+
+# Implement Payment Dispute and Chargeback Resolution
+
+Confirm:
+- Which reason codes are auto-contested, auto-accepted, or routed to manual review
+- Evidence requirements per reason code and network
+- Deadline source of truth: network, provider, or internal buffer
+- Auto-accept threshold below the cost of contesting a case
+- Provisional debit timing and merchant reserve policy
+- Liability-shift rules for authenticated or tokenized transactions
+- Escalation path and approval for pre-arbitration or arbitration
+- Chargeback-ratio thresholds and the resulting account actions
+- Customer communication policy while a case is active
+- How one dispute binds to exactly one payment and order, including split or partial disputes
+
+Follow project conventions and protect:
+- One chargeback notification must not open more than one case
+- A case must bind the intended payer, merchant, order, tenant, and payment
+- Provisional debit or credit must apply exactly once per case
+- Evidence deadlines must be enforced from the authoritative reason-code table
+- Case, ledger, order, and customer records must converge on one outcome
+- Liability-shift and auto-accept policy must not bypass required manual review
+- Chargeback-ratio status must reflect confirmed outcomes only
+- Cardholder data and evidence must remain protected and access-scoped
+
+Add all core tests and summarize decisions, files, state changes, recovery, privacy and security controls, and remaining gaps.

--- a/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/PATHS_AND_EDGE_CASES.md
+++ b/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/PATHS_AND_EDGE_CASES.md
@@ -1,0 +1,31 @@
+# Paths and Edge Cases
+
+## Supported paths
+- Dispute or chargeback intake from a provider webhook or manual report
+- Reason-code classification and evidence-deadline assignment
+- Evidence collection and representment submission
+- Auto-accept and auto-contest policy for low-value or clear-cut cases
+- Liability-shift determination for authenticated transactions
+- Escalation to pre-arbitration or arbitration where the network allows it
+- Provisional debit, reserve adjustment, and final ledger settlement
+- Chargeback-ratio monitoring and merchant risk-program status
+
+## Normal paths
+- A valid dispute links to its original payment once and complete evidence wins the case before the deadline
+- A low-value dispute is auto-accepted by policy without wasted evidence effort
+- An authenticated transaction wins through liability shift
+
+## Denied paths
+- A dispute references a payment or order that does not exist or was never captured
+- Evidence is submitted after the network deadline
+- The dispute amount or currency does not match the original payment
+- The actor lacks access to the dispute case or tenant
+
+## Timing, concurrency, and boundaries
+- Two dispute webhooks for the same case arrive together
+- The evidence deadline falls at a timezone or network cutover boundary
+- A case escalates to pre-arbitration after an initial win or loss
+- The cardholder withdraws the dispute after representment was submitted
+- The disputed order was already fully refunded before the case opened
+
+Cover valid, invalid, duplicate, expired, stale, replayed, repeated, simultaneous, partially completed, unauthorized, and recovery outcomes.

--- a/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/PERMISSION_AND_ABUSE_GUIDE.md
+++ b/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/PERMISSION_AND_ABUSE_GUIDE.md
@@ -1,0 +1,20 @@
+# Permission and Abuse Guide
+
+## Permission boundaries
+- One chargeback notification must not open more than one case
+- A case must bind the intended payer, merchant, order, tenant, and payment
+- Provisional debit or credit must apply exactly once per case
+- Evidence deadlines must be enforced from the authoritative reason-code table
+- Liability-shift and auto-accept policy must not bypass required manual review
+
+## Misuse paths
+- Duplicate provisional debit — Retried webhooks debit the merchant ledger twice for one dispute
+- Missed deadline — Valid evidence submitted late is rejected, turning a winnable case into a loss
+- Wrong payment linkage — A dispute attaches to the wrong order or payment and corrupts the ledger and customer record
+- False resolution status — A pending or under-review case is reported as won or lost prematurely
+- Liability-shift miscalculation — The merchant absorbs a loss despite authentication that should shift liability to the issuer
+- Duplicate dispute case — A provider retry or duplicate notification opens two cases for one chargeback
+- Chargeback-ratio blind spot — A missed risk-program escalation risks account suspension or termination
+- Sensitive data exposure — Card number fragments, personal data, or evidence documents reach unsafe logs or unauthorized viewers
+
+Protect actor identity, tenant scope, authoritative business objects, cardholder and evidence data, provider proof, support tools, and audit records. Deny uncertain ownership or permission.

--- a/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/PRODUCT_AND_BUSINESS_GUIDE.md
+++ b/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/PRODUCT_AND_BUSINESS_GUIDE.md
@@ -1,0 +1,85 @@
+# Product and Business Guide
+
+## Boundary
+Starts when a cardholder, issuer, or network raises a dispute or chargeback against a previously captured or settled payment. Ends when the case is won, lost, accepted, withdrawn, or expires, with the ledger, order, and customer outcome recorded consistently, including any escalation to a final network decision.
+
+## People and systems
+- Cardholder or authorized disputant
+- Issuing bank or card network
+- Acquirer or payment provider
+- Merchant dispute or chargeback team
+- Payment orchestration and ledger services
+- Fraud and risk team
+- Customer support and notification services
+- Finance and reconciliation team
+
+## Things created or changed
+- Dispute or chargeback case
+- Reason code and network evidence deadline
+- Evidence bundle and representment submission
+- Provisional debit or credit and reserve adjustment
+- Dispute outcome and liability decision
+- Ledger entry, chargeback fee, and settlement record
+- Merchant chargeback-ratio and risk-program status
+- Customer communication record
+
+## Stages
+- Dispute case: opened → evidence-due → submitted → under-review → won, lost, accepted, expired, or withdrawn
+- Representment: not started → drafted → submitted → accepted or rejected → pre-arbitration or arbitration where the network allows it
+- Funds: captured → provisionally debited → reinstated on win or finalized reversal on loss
+- Merchant risk: normal → monitored → excessive-chargeback program
+
+## Product decisions
+- Which reason codes are auto-contested, auto-accepted, or routed to manual review
+- Evidence requirements per reason code and network
+- Deadline source of truth: network, provider, or internal buffer
+- Auto-accept threshold below the cost of contesting a case
+- Provisional debit timing and merchant reserve policy
+- Liability-shift rules for authenticated or tokenized transactions
+- Escalation path and approval for pre-arbitration or arbitration
+- Chargeback-ratio thresholds and the resulting account actions
+- Customer communication policy while a case is active
+- How one dispute binds to exactly one payment and order, including split or partial disputes
+
+## Happy paths
+- A valid dispute links to its original payment once and complete evidence is submitted before the deadline, winning the case
+- A low-value dispute is auto-accepted by policy without wasted evidence effort
+- An authenticated transaction wins through liability shift
+
+## Negative paths
+- A dispute references a payment or order that does not exist or was never captured
+- Evidence is submitted after the network deadline
+- The dispute amount or currency does not match the original payment
+- The actor lacks access to the dispute case or tenant
+
+## Edge cases
+- Two dispute webhooks for the same case arrive together
+- The evidence deadline falls at a timezone or network cutover boundary
+- A case escalates to pre-arbitration after an initial win or loss
+- The cardholder withdraws the dispute after representment was submitted
+- The disputed order was already fully refunded before the case opened
+- Merchant chargeback ratio crosses the risk threshold mid-case
+
+## Acceptance criteria
+1. Only a dispute matching an existing captured or settled payment may open a case
+2. Each chargeback notification must resolve to one case bound to actor, tenant, order, and payment
+3. Provisional debit or credit must apply exactly once per case even under retried webhooks
+4. Evidence submitted after the network deadline must be rejected or flagged, never accepted silently as timely
+5. Reason code, deadline, and required evidence type must come from one authoritative table
+6. Case outcome must reconcile ledger, order, and customer records without contradiction
+7. Auto-accept and auto-contest policy must not bypass manual review above the configured threshold
+8. Liability-shift determination must rely on authoritative authentication evidence, not assumption
+9. Chargeback-ratio and risk-program status must update from confirmed outcomes only, not opened cases
+10. Dispute evidence and cardholder data must remain access-scoped and auditable
+
+## Business risks
+| Risk | Business consequence |
+|---|---|
+| Duplicate provisional debit | Retried webhooks debit the merchant ledger twice for one dispute |
+| Missed deadline | Valid evidence submitted late is rejected, turning a winnable case into a loss |
+| Wrong payment linkage | A dispute attaches to the wrong order or payment and corrupts the ledger and customer record |
+| False resolution status | A pending or under-review case is reported as won or lost prematurely |
+| Liability-shift miscalculation | The merchant absorbs a loss despite authentication that should shift liability to the issuer |
+| Duplicate dispute case | A provider retry or duplicate notification opens two cases for one chargeback |
+| Chargeback-ratio blind spot | A missed risk-program escalation risks account suspension or termination |
+| Sensitive data exposure | Card number fragments, personal data, or evidence documents reach unsafe logs or unauthorized viewers |

--- a/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/README.md
+++ b/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/README.md
@@ -1,0 +1,28 @@
+# Payment Dispute and Chargeback Resolution
+
+Starts when a cardholder, issuer, or network raises a dispute or chargeback against a previously captured or settled payment. Ends when the case is won, lost, accepted, withdrawn, or expires, with the ledger, order, and customer outcome recorded consistently, including any escalation to a final network decision.
+
+| Task | File |
+|---|---|
+| Product and business | [PRODUCT_AND_BUSINESS_GUIDE.md](PRODUCT_AND_BUSINESS_GUIDE.md) |
+| Engineering | [ENGINEERING_GUIDE.md](ENGINEERING_GUIDE.md) |
+| Testing | [TESTING_GUIDE.md](TESTING_GUIDE.md) |
+| Core 20 | [CORE_20_SCENARIOS.md](CORE_20_SCENARIOS.md) |
+| Paths and edge cases | [PATHS_AND_EDGE_CASES.md](PATHS_AND_EDGE_CASES.md) |
+| Permissions and misuse | [PERMISSION_AND_ABUSE_GUIDE.md](PERMISSION_AND_ABUSE_GUIDE.md) |
+| Retry and recovery | [RETRY_AND_RECOVERY_GUIDE.md](RETRY_AND_RECOVERY_GUIDE.md) |
+
+## Included
+- dispute or chargeback intake, reason-code classification, and network deadline tracking
+- evidence collection, representment, and escalation to pre-arbitration or arbitration
+- provisional debit or credit, reserve adjustment, and final ledger settlement
+- dispute outcome, liability-shift determination, and customer communication
+- chargeback-ratio monitoring and merchant risk-program status
+
+## Excluded
+- checkout payment authorization and capture
+- customer-initiated cancellation and refund before any dispute is raised
+- fraud or risk screening performed at checkout time
+- subscription renewal and cancellation
+
+The five `*_SKILL.md` files are self-contained.

--- a/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/RETRY_AND_RECOVERY_GUIDE.md
+++ b/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/RETRY_AND_RECOVERY_GUIDE.md
@@ -1,0 +1,16 @@
+# Retry and Recovery Guide
+
+## Partial failures
+- Provisional debit succeeds but the case or ledger update fails
+- Representment is submitted but the network confirmation is lost
+- Case resolves won or lost but the order or customer record update fails
+- Dispute-opened webhook is accepted but case creation fails
+- Chargeback-ratio aggregation fails after a confirmed outcome
+- Escalation to pre-arbitration succeeds but local case state is not updated
+
+## Recovery rules
+- Use the network case identifier and provider idempotency key as the stable case identity.
+- Re-read authoritative payment, order, case, and network status before retrying.
+- Never repeat a provisional debit or representment submission solely because a response or local update was lost.
+- Distinguish opened, under-review, won, lost, accepted, expired, and withdrawn outcomes.
+- Reconcile provider, case, ledger, order, and customer records to one outcome.

--- a/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/REVIEW_BUSINESS_RISK_SKILL.md
+++ b/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/REVIEW_BUSINESS_RISK_SKILL.md
@@ -1,0 +1,18 @@
+---
+name: review-dispute-chargeback-risk
+description: Review customer, revenue, permission, privacy, and operational risks in Payment Dispute and Chargeback Resolution. Use when founders, PMs, or engineering managers need prioritized consequences, controls, tests, and release concerns.
+---
+
+# Review Payment Dispute and Chargeback Resolution Risk
+
+Review intake, linkage, evidence, deadline, concurrency, escalation, ledger, and privacy paths. Prioritize:
+- Duplicate provisional debit — Retried webhooks debit the merchant ledger twice for one dispute
+- Missed deadline — Valid evidence submitted late is rejected, turning a winnable case into a loss
+- Wrong payment linkage — A dispute attaches to the wrong order or payment and corrupts the ledger and customer record
+- False resolution status — A pending or under-review case is reported as won or lost prematurely
+- Liability-shift miscalculation — The merchant absorbs a loss despite authentication that should shift liability to the issuer
+- Duplicate dispute case — A provider retry or duplicate notification opens two cases for one chargeback
+- Chargeback-ratio blind spot — A missed risk-program escalation risks account suspension or termination
+- Sensitive data exposure — Card number fragments, personal data, or evidence documents reach unsafe logs or unauthorized viewers
+
+For each material risk, explain trigger, behavior, business consequence, protection, decision or test, and acceptance condition.

--- a/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/TESTING_GUIDE.md
+++ b/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/TESTING_GUIDE.md
@@ -1,0 +1,243 @@
+# Testing Guide
+
+Check authoritative records, financial or inventory changes, permissions, external effects, recovery, and audit—not only responses.
+
+## 1. Valid dispute opens against a captured payment
+
+**Given:** A dispute notification references an existing captured or settled payment
+
+**When:** The case-intake path runs
+
+**Expect:** One case is created and bound to the payment, order, payer, and tenant
+
+**Must not happen:** A case opens against a payment that was never captured or does not exist
+
+**Best test levels:** Integration and end-to-end.
+
+## 2. Complete evidence is submitted before the deadline
+
+**Given:** A case has a reason code, required evidence types, and an active deadline
+
+**When:** A complete evidence bundle is submitted before the deadline
+
+**Expect:** The case advances to under-review with the submission recorded
+
+**Must not happen:** Incomplete or wrong evidence is recorded as a complete submission
+
+**Best test levels:** Integration.
+
+## 3. Low-value dispute is auto-accepted by policy
+
+**Given:** A case amount falls below the configured cost-to-fight threshold
+
+**When:** Auto-accept policy evaluates the case
+
+**Expect:** The case is accepted automatically and funds are finalized without a contest attempt
+
+**Must not happen:** The case is contested past the cost-to-fight threshold without approval
+
+**Best test levels:** Unit and integration.
+
+## 4. Authenticated transaction wins on liability shift
+
+**Given:** The disputed payment carries valid strong-customer-authentication evidence
+
+**When:** Liability-shift evaluation runs
+
+**Expect:** The case wins on liability shift and the merchant is not debited
+
+**Must not happen:** Liability shift is ignored and the merchant absorbs an avoidable loss
+
+**Best test levels:** Integration.
+
+## 5. Required dispute fields are missing
+
+**Given:** A dispute notification lacks a payment reference, amount, or reason code
+
+**When:** Case intake validates the notification
+
+**Expect:** Case creation is rejected before any ledger or order effect
+
+**Must not happen:** A guessed or unlinked case is created
+
+**Best test levels:** Unit and API.
+
+## 6. Dispute amount or currency mismatches the payment
+
+**Given:** The dispute amount or currency differs from the original captured payment
+
+**When:** The case is linked to the payment
+
+**Expect:** The mismatch is flagged for manual review before any automated resolution
+
+**Must not happen:** The mismatch is silently reconciled instead of flagged
+
+**Best test levels:** Unit and integration.
+
+## 7. Actor without dispute-team access submits evidence
+
+**Given:** An authenticated actor lacks dispute-team access to the case's tenant
+
+**When:** They attempt to submit or modify evidence
+
+**Expect:** Ownership and scope checks deny the action
+
+**Must not happen:** An unauthorized actor modifies or submits case evidence
+
+**Best test levels:** Authorization and security.
+
+## 8. Evidence deadline is reached at a timezone boundary
+
+**Given:** A submission arrives immediately before, at, and after the evidence deadline across a timezone or network cutover
+
+**When:** Trusted time and the authoritative deadline are checked
+
+**Expect:** One explicit boundary rule is applied consistently
+
+**Must not happen:** Clock differences extend or shorten the window unpredictably
+
+**Best test levels:** Unit with controlled time.
+
+## 9. Two dispute webhooks arrive together for one case
+
+**Given:** Two dispute-opened webhooks for the same network case ID arrive concurrently
+
+**When:** Both are processed
+
+**Expect:** Idempotency allows exactly one case and one provisional debit
+
+**Must not happen:** The provisional debit is applied twice
+
+**Best test levels:** Concurrency integration.
+
+## 10. Provider retries the dispute-opened notification
+
+**Given:** The provider resends a dispute-opened notification already processed
+
+**When:** The retry is received
+
+**Expect:** The existing case is returned without creating another one
+
+**Must not happen:** A duplicate case is created for one chargeback
+
+**Best test levels:** Integration.
+
+## 11. Representment response from the network is lost
+
+**Given:** A representment was submitted but no confirmation was received by the caller
+
+**When:** The submission is retried or status is queried
+
+**Expect:** The original representment is found and reused
+
+**Must not happen:** Resubmission creates a second representment instead of resuming the same case
+
+**Best test levels:** API and integration.
+
+## 12. Case is escalated to pre-arbitration after resolution
+
+**Given:** A resolved case receives a network escalation to pre-arbitration or arbitration
+
+**When:** The escalation notification is processed
+
+**Expect:** The case reopens into the escalation stage with prior resolution preserved as history
+
+**Must not happen:** The case is treated as final and closed prematurely
+
+**Best test levels:** Integration.
+
+## 13. Merchant chargeback ratio crosses the risk threshold
+
+**Given:** Confirmed dispute outcomes push the merchant's chargeback ratio above the configured threshold
+
+**When:** Ratio aggregation runs
+
+**Expect:** The merchant risk-program status updates and the configured escalation fires
+
+**Must not happen:** Risk-program escalation is not triggered
+
+**Best test levels:** Integration.
+
+## 14. Cardholder withdraws the dispute after representment
+
+**Given:** A cardholder withdrawal notification arrives for a case with submitted representment
+
+**When:** The withdrawal is processed
+
+**Expect:** The case closes as withdrawn and provisionally debited funds are reinstated
+
+**Must not happen:** The case stays open or funds are not reinstated
+
+**Best test levels:** Integration.
+
+## 15. Provisional debit succeeds but the ledger write fails
+
+**Given:** The provider applies a provisional debit while the local ledger entry fails to persist
+
+**When:** Recovery runs
+
+**Expect:** The authoritative provider state repairs the same ledger entry without a new debit
+
+**Must not happen:** A second debit is applied blindly on retry
+
+**Best test levels:** Integration.
+
+## 16. Dispute references another tenant's payment
+
+**Given:** A dispute notification's payment reference belongs to a different tenant than the case actor
+
+**When:** Case linkage is attempted
+
+**Expect:** Tenant and payment binding deny the linkage
+
+**Must not happen:** Identifiers cross the tenant boundary into another merchant's case
+
+**Best test levels:** Authorization and security.
+
+## 17. Resolution arrives after the order was already refunded
+
+**Given:** The disputed order was fully refunded before the case resolved
+
+**When:** The case resolution is processed
+
+**Expect:** The resolution is reconciled against the existing refund without moving funds again
+
+**Must not happen:** The ledger reverses the same funds twice
+
+**Best test levels:** Integration and operations.
+
+## 18. Evidence bundle contains cardholder PAN or secrets
+
+**Given:** An evidence bundle or case record contains card-number fragments or personal data
+
+**When:** The bundle is stored, logged, or displayed
+
+**Expect:** Sensitive fields are masked or excluded outside authorized access
+
+**Must not happen:** Sensitive data enters logs or unauthorized storage
+
+**Best test levels:** Security and log inspection.
+
+## 19. Final network outcome arrives after internal tracking expired
+
+**Given:** The internal deadline-tracking record for a case has already expired or archived
+
+**When:** The authoritative final network outcome is received
+
+**Expect:** The case record is reopened or updated to match the authoritative outcome
+
+**Must not happen:** Stale internal state contradicts the authoritative network outcome
+
+**Best test levels:** Integration.
+
+## 20. Case resolves but the order or customer record update fails
+
+**Given:** A case resolves won or lost while the order or customer-facing record update fails
+
+**When:** Reconciliation runs
+
+**Expect:** All systems converge on the same outcome without a contradictory or duplicate ledger effect
+
+**Must not happen:** The ledger, order, and customer outcome show contradictory states
+
+**Best test levels:** Integration and operations.

--- a/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/TEST_WORKFLOW_SKILL.md
+++ b/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/TEST_WORKFLOW_SKILL.md
@@ -1,0 +1,30 @@
+---
+name: test-dispute-chargeback
+description: Design, implement, or review tests for Payment Dispute and Chargeback Resolution. Use when complete normal, invalid, boundary, concurrency, replay, failure, recovery, permission, privacy, and misuse scenarios are needed.
+---
+
+# Test Payment Dispute and Chargeback Resolution
+
+Cover:
+1. Valid dispute opens against a captured payment
+2. Complete evidence is submitted before the deadline
+3. Low-value dispute is auto-accepted by policy
+4. Authenticated transaction wins on liability shift
+5. Required dispute fields are missing
+6. Dispute amount or currency mismatches the payment
+7. Actor without dispute-team access submits evidence
+8. Evidence deadline is reached at a timezone boundary
+9. Two dispute webhooks arrive together for one case
+10. Provider retries the dispute-opened notification
+11. Representment response from the network is lost
+12. Case is escalated to pre-arbitration after resolution
+13. Merchant chargeback ratio crosses the risk threshold
+14. Cardholder withdraws the dispute after representment
+15. Provisional debit succeeds but the ledger write fails
+16. Dispute references another tenant's payment
+17. Resolution arrives after the order was already refunded
+18. Evidence bundle contains cardholder PAN or secrets
+19. Final network outcome arrives after internal tracking expired
+20. Case resolves but the order or customer record update fails
+
+For each scenario write Given, When, expected response and authoritative state changes, forbidden outcomes, test level, fixtures, controlled time or provider behavior, and cleanup.

--- a/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/UNDERSTAND_CODE_SKILL.md
+++ b/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/UNDERSTAND_CODE_SKILL.md
@@ -1,0 +1,19 @@
+---
+name: understand-dispute-chargeback-code
+description: Trace and explain Payment Dispute and Chargeback Resolution across an existing codebase. Use when locating intake, linkage, evidence, deadline, ledger, escalation, monitoring, and test paths.
+---
+
+# Understand Payment Dispute and Chargeback Resolution Code
+
+Trace:
+1. Dispute-webhook, manual-report, evidence-submission, and case-status entry points
+2. Actor, account, tenant, and case ownership checks
+3. Payment and order lookup used to bind a new case
+4. Case model, reason code, deadline, idempotency, and state-machine controls
+5. Evidence-bundle storage, representment drafting, and submission paths
+6. Provisional debit or credit, reserve adjustment, and ledger posting
+7. Liability-shift, auto-accept, and auto-contest policy evaluation
+8. Chargeback-ratio aggregation and risk-program status updates
+9. Audit, privacy, monitoring, support tools, and tests
+
+Explain actors, ownership, states, transitions, financial effects, failures, retries, security boundaries, monitoring, tests, and areas needing verification. Cite files and symbols.

--- a/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/WRITE_PRODUCT_SPEC_SKILL.md
+++ b/prebuilt-workflow-paths/payment-dispute-and-chargeback-resolution/WRITE_PRODUCT_SPEC_SKILL.md
@@ -1,0 +1,20 @@
+---
+name: write-dispute-chargeback-spec
+description: Write or review a product specification for Payment Dispute and Chargeback Resolution. Use when defining actors, states, deadline or evidence rules, policy decisions, edge cases, acceptance criteria, recovery, or business risks.
+---
+
+# Write a Payment Dispute and Chargeback Resolution Specification
+
+Use application-native terms. Decide:
+- Which reason codes are auto-contested, auto-accepted, or routed to manual review
+- Evidence requirements per reason code and network
+- Deadline source of truth: network, provider, or internal buffer
+- Auto-accept threshold below the cost of contesting a case
+- Provisional debit timing and merchant reserve policy
+- Liability-shift rules for authenticated or tokenized transactions
+- Escalation path and approval for pre-arbitration or arbitration
+- Chargeback-ratio thresholds and the resulting account actions
+- Customer communication policy while a case is active
+- How one dispute binds to exactly one payment and order, including split or partial disputes
+
+Write scope, actors, objects, states, paths, customer and financial outcomes, permissions, recovery, privacy, misuse, acceptance criteria, and unanswered decisions.


### PR DESCRIPTION
Every existing payment pack ends at capture; checkout-payment-authorization-and-capture explicitly excludes refunds, disputes, and chargebacks. This adds a 19th MECE-bounded pack covering dispute intake, evidence/representment, liability shift, provisional-debit reconciliation, escalation, and chargeback-ratio risk monitoring, with all 13 required files and 20 distinct core scenarios. Links the pack from the collection README and updates its summary counts.

## Problem and scope

Describe the user problem and the focused scope of this change.

## What changed

Summarize the implementation or content change.

## Verification

List the commands, fixtures, public repositories, and outputs used to verify the change.

- [ ] `python -m black --config .github/quality/pyproject.toml --check .github/quality/tests`
- [ ] `python -m flake8 --config .github/quality/.flake8 .github/quality/tests`
- [ ] `python -m pytest -c .github/quality/pyproject.toml .github/quality/tests`
- [ ] I used UnvibeCode on a representative repository when the change affects code analysis, CLI behaviour, engineering guidance, or code-specific claims.
- [ ] I updated documentation for changed user-facing behaviour.
- [ ] I included no credentials, proprietary source, customer data, generated customer reports, or unsanitized logs.

## Workflow-pack checks

Complete these items only when adding or changing a pre-built workflow pack.

- [ ] The start, end, included scope, and excluded scope are explicit.
- [ ] The pack owns one primary business outcome and does not duplicate an existing pack.
- [ ] The 20 core scenarios are distinct and collectively cover the declared boundary.
- [ ] Every core scenario states what must not happen.
- [ ] All 13 required files use consistent `People and systems`, `Things created or changed`, `Stages`, and outcome names.

## Remaining limitations

List any known limitation or follow-up issue.
