### PR TITLE
[Improvement] Add LLM Integrations guide to Cheatsheet

### DIFF
--- a/AI Engineering Cheatsheet/README.md
+++ b/AI Engineering Cheatsheet/README.md
@@ -21,6 +21,7 @@ Eleven focused guides covering:
 - Security
 - Testing
 - Observability
+- LLM Integrations
 
 Each guide includes a compact visual, ten critical questions, warning signs, evidence to collect, and a prompt for challenging the design with an LLM or reviewer.
 

--- a/AI Engineering Cheatsheet/smart_questions_before_you_build/11-llm-integrations.md
+++ b/AI Engineering Cheatsheet/smart_questions_before_you_build/11-llm-integrations.md
@@ -1,0 +1,44 @@
+# 11 — LLM Integrations: Context, Safety, and Structured Output
+
+> An LLM is not a deterministic function. It is an unbounded external dependency that requires strict input sanitization, runtime boundaries, and output validation.
+
+```mermaid
+flowchart TD
+    A["User Input / Event"] --> B["Sanitize & Inject Context"]
+    B --> C["Prompt Assembly"]
+    C --> D["LLM Provider API"]
+    D -. timeout/failure .-> E["Graceful Degradation / Fallback"]
+    D --> F["Parse & Validate Output"]
+    F -. invalid schema .-> G["Retry or Reject"]
+    F --> H["Execute Business Logic"]
+```
+
+## Stop and answer
+
+- [ ] Which component is responsible for enforcing the prompt boundary and preventing prompt injection?
+- [ ] How is the context window managed when user input, retrieved evidence, and conversation history exceed token limits?
+- [ ] What is the exact fallback behaviour if the LLM provider API times out, rate-limits, or degrades in quality?
+- [ ] Where is the LLM output explicitly parsed, typed, and validated before being passed to business logic?
+- [ ] What are the exact recovery steps when the model hallucinates an invalid schema or incorrect reference?
+- [ ] How are Personally Identifiable Information (PII) and sensitive tenant data scrubbed before leaving the network boundary?
+- [ ] Which operations require a human-in-the-loop for approval before the LLM can execute an action?
+- [ ] How are token usage, latency, and cost attributed back to a specific tenant or feature?
+- [ ] What prevents the model from generating content that violates compliance or brand safety guidelines?
+- [ ] How can the application upgrade to a newer model version without breaking the current prompt contracts?
+
+## Warning signs
+
+- The application blindly trusts and executes Markdown, JSON, or code generated directly by the LLM.
+- There is no distinction in the prompt between system instructions and untrusted user input.
+- A single LLM API failure results in a complete application crash instead of a graceful degradation.
+
+## Evidence before code
+
+- Fallback and retry strategy for the provider API
+- Output validation schemas (e.g., Pydantic or Zod)
+- Prompt injection and boundary testing plan
+- Data sanitization policy for external API calls
+
+## Ask an LLM or reviewer
+
+> “Attack this integration with a 50-second timeout, a malicious user prompt that overrides instructions, and an output that is completely malformed JSON. Show where the system fails to contain the blast radius.”


### PR DESCRIPTION
## Problem and scope

The AI Engineering Cheatsheet collection was missing a guide for LLM integrations, context management, and structured output parsing.

## What changed

Added `11-llm-integrations.md` to the `smart_questions_before_you_build/` directory and updated the main `README.md` to include it.

## Verification

List the commands, fixtures, public repositories, and outputs used to verify the change.

- [ ] `python -m black --config .github/quality/pyproject.toml --check .github/quality/tests`
- [ ] `python -m flake8 --config .github/quality/.flake8 .github/quality/tests`
- [ ] `python -m pytest -c .github/quality/pyproject.toml .github/quality/tests`
- [x] I used UnvibeCode on a representative repository when the change affects code analysis, CLI behaviour, engineering guidance, or code-specific claims.
- [ ] I updated documentation for changed user-facing behaviour.
- [x] I included no credentials, proprietary source, customer data, generated customer reports, or unsanitized logs.

## Workflow-pack checks

Complete these items only when adding or changing a pre-built workflow pack.

- [ ] The start, end, included scope, and excluded scope are explicit.
- [ ] The pack owns one primary business outcome and does not duplicate an existing pack.
- [ ] The 20 core scenarios are distinct and collectively cover the declared boundary.
- [ ] Every core scenario states what must not happen.
- [ ] All 13 required files use consistent `People and systems`, `Things created or changed`, `Stages`, and outcome names.

## Remaining limitations

None
