### PR TITLE
fix: fail quality tests loud when workflow pack directory is empty

### DIFF
--- a/.github/quality/tests/test_repository_quality.py
+++ b/.github/quality/tests/test_repository_quality.py
@@ -29,7 +29,12 @@ CORE_SCENARIO_ROW = re.compile(r"^\|\s*(\d+)\s*\|", re.MULTILINE)
 
 
 def workflow_packs():
-    return sorted(path for path in PACKS_ROOT.iterdir() if path.is_dir())
+    packs = sorted(path for path in PACKS_ROOT.iterdir() if path.is_dir())
+    assert packs, (
+        f"No workflow pack directories found in {PACKS_ROOT}. "
+        "If the directory was moved or renamed, update PACKS_ROOT in this file."
+    )
+    return packs
 
 
 @pytest.mark.parametrize("pack", workflow_packs(), ids=lambda path: path.name)


### PR DESCRIPTION
## Problem and scope

If `prebuilt-workflow-paths/` is empty or missing, all pack-specific quality tests run with zero parametrized cases and pytest reports PASS. The entire quality suite goes green without validating anything. This is a focused fix in `test_repository_quality.py` only.

## What changed

Added an assert in `workflow_packs()` to fail loud when no workflow pack directories are found. Converts a silent false-negative into an immediate, actionable error.

**Closes:** #151

## Verification

- [x] `python -m black --config .github/quality/pyproject.toml --check .github/quality/tests`
- [x] `python -m flake8 --config .github/quality/.flake8 .github/quality/tests`
- [x] `python -m pytest -c .github/quality/pyproject.toml .github/quality/tests`
- [ ] I used UnvibeCode on a representative repository when the change affects code analysis, CLI behaviour, engineering guidance, or code-specific claims.
- [ ] I updated documentation for changed user-facing behaviour.
- [x] I included no credentials, proprietary source, customer data, generated customer reports, or unsanitized logs.

## Workflow-pack checks

N/A — no workflow pack added or changed.

## Remaining limitations

None. The fix is backward-compatible — existing CI with 18 packs passes unchanged.
