### PR TITLE
Add UnvibeCode contributor and Top 10 credentials

### DIFF
--- a/docs/OSS_Contributor_Credentials/README.md
+++ b/docs/OSS_Contributor_Credentials/README.md
@@ -1,0 +1,25 @@
+# UnvibeCode Open Source Contributor Credentials
+
+This directory contains public credential records for selected contributors to the **UnvibeCode Engineering Challenge 2026**.
+
+Each credential is issued by **Alphashots.ai** and can be referenced from LinkedIn under **Licenses & Certifications**.
+
+## Credential format
+
+- **Credential name:** Open Source Contributor — UnvibeCode
+- **Issuing organization:** Alphashots.ai
+- **Issue date:** September 2026
+- **Repository:** https://github.com/FinanceFlash/unvibecode
+
+## Issued credentials
+
+| Credential ID | Contributor |
+| --- | --- |
+| UVC26-OSC-001 | Hariom Hatwate |
+| UVC26-OSC-002 | Drashan Gowda A.N |
+| UVC26-OSC-003 | Aditya Sarade |
+| UVC26-OSC-004 | Shruti Thakur |
+| UVC26-OSC-005 | Dhanush M |
+| UVC26-OSC-006 | Subhankar Nath |
+
+Each credential ID links to an individual Markdown record in this directory.

--- a/docs/OSS_Contributor_Credentials/README.md
+++ b/docs/OSS_Contributor_Credentials/README.md
@@ -1,8 +1,8 @@
 # UnvibeCode Open Source Contributor Credentials
 
-This directory contains public credential records for selected contributors to the **UnvibeCode Engineering Challenge 2026**.
+This directory contains public verification records for recognized **Open Source Contributors to UnvibeCode**.
 
-Each credential is issued by **Alphashots.ai** and can be referenced from LinkedIn under **Licenses & Certifications**.
+Each credential is issued by **Alphashots.ai** and may be referenced from LinkedIn under **Licenses & Certifications**, or included on a resume or portfolio as a public verification record.
 
 ## Credential format
 
@@ -22,4 +22,4 @@ Each credential is issued by **Alphashots.ai** and can be referenced from Linked
 | UVC26-OSC-005 | Dhanush M |
 | UVC26-OSC-006 | Subhankar Nath |
 
-Each credential ID links to an individual Markdown record in this directory.
+Each credential ID has an individual public verification record in this directory.

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-001.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-001.md
@@ -4,8 +4,7 @@
 **Credential ID:** UVC26-OSC-001  
 **Issuing organization:** Alphashots.ai  
 **Issue date:** September 2026  
-**Program:** UnvibeCode Engineering Challenge 2026  
 **Status:** Open Source Contributor  
 **Repository:** https://github.com/FinanceFlash/unvibecode
 
-This credential recognizes Hariom Hatwate for an open-source contribution to UnvibeCode during the UnvibeCode Engineering Challenge 2026.
+This credential recognizes **Hariom Hatwate** as an **Open Source Contributor to UnvibeCode**.

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-001.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-001.md
@@ -1,0 +1,11 @@
+# Open Source Contributor — UnvibeCode
+
+**Contributor:** Hariom Hatwate  
+**Credential ID:** UVC26-OSC-001  
+**Issuing organization:** Alphashots.ai  
+**Issue date:** September 2026  
+**Program:** UnvibeCode Engineering Challenge 2026  
+**Status:** Open Source Contributor  
+**Repository:** https://github.com/FinanceFlash/unvibecode
+
+This credential recognizes Hariom Hatwate for an open-source contribution to UnvibeCode during the UnvibeCode Engineering Challenge 2026.

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-002.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-002.md
@@ -4,8 +4,7 @@
 **Credential ID:** UVC26-OSC-002  
 **Issuing organization:** Alphashots.ai  
 **Issue date:** September 2026  
-**Program:** UnvibeCode Engineering Challenge 2026  
 **Status:** Open Source Contributor  
 **Repository:** https://github.com/FinanceFlash/unvibecode
 
-This credential recognizes Drashan Gowda A.N for an open-source contribution to UnvibeCode during the UnvibeCode Engineering Challenge 2026.
+This credential recognizes **Drashan Gowda A.N** as an **Open Source Contributor to UnvibeCode**.

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-002.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-002.md
@@ -1,0 +1,11 @@
+# Open Source Contributor — UnvibeCode
+
+**Contributor:** Drashan Gowda A.N  
+**Credential ID:** UVC26-OSC-002  
+**Issuing organization:** Alphashots.ai  
+**Issue date:** September 2026  
+**Program:** UnvibeCode Engineering Challenge 2026  
+**Status:** Open Source Contributor  
+**Repository:** https://github.com/FinanceFlash/unvibecode
+
+This credential recognizes Drashan Gowda A.N for an open-source contribution to UnvibeCode during the UnvibeCode Engineering Challenge 2026.

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-003.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-003.md
@@ -4,8 +4,7 @@
 **Credential ID:** UVC26-OSC-003  
 **Issuing organization:** Alphashots.ai  
 **Issue date:** September 2026  
-**Program:** UnvibeCode Engineering Challenge 2026  
 **Status:** Open Source Contributor  
 **Repository:** https://github.com/FinanceFlash/unvibecode
 
-This credential recognizes Aditya Sarade for an open-source contribution to UnvibeCode during the UnvibeCode Engineering Challenge 2026.
+This credential recognizes **Aditya Sarade** as an **Open Source Contributor to UnvibeCode**.

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-003.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-003.md
@@ -1,0 +1,11 @@
+# Open Source Contributor — UnvibeCode
+
+**Contributor:** Aditya Sarade  
+**Credential ID:** UVC26-OSC-003  
+**Issuing organization:** Alphashots.ai  
+**Issue date:** September 2026  
+**Program:** UnvibeCode Engineering Challenge 2026  
+**Status:** Open Source Contributor  
+**Repository:** https://github.com/FinanceFlash/unvibecode
+
+This credential recognizes Aditya Sarade for an open-source contribution to UnvibeCode during the UnvibeCode Engineering Challenge 2026.

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-004.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-004.md
@@ -1,0 +1,11 @@
+# Open Source Contributor — UnvibeCode
+
+**Contributor:** Shruti Thakur  
+**Credential ID:** UVC26-OSC-004  
+**Issuing organization:** Alphashots.ai  
+**Issue date:** September 2026  
+**Program:** UnvibeCode Engineering Challenge 2026  
+**Status:** Open Source Contributor  
+**Repository:** https://github.com/FinanceFlash/unvibecode
+
+This credential recognizes Shruti Thakur for an open-source contribution to UnvibeCode during the UnvibeCode Engineering Challenge 2026.

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-004.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-004.md
@@ -4,8 +4,7 @@
 **Credential ID:** UVC26-OSC-004  
 **Issuing organization:** Alphashots.ai  
 **Issue date:** September 2026  
-**Program:** UnvibeCode Engineering Challenge 2026  
 **Status:** Open Source Contributor  
 **Repository:** https://github.com/FinanceFlash/unvibecode
 
-This credential recognizes Shruti Thakur for an open-source contribution to UnvibeCode during the UnvibeCode Engineering Challenge 2026.
+This credential recognizes **Shruti Thakur** as an **Open Source Contributor to UnvibeCode**.

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-005.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-005.md
@@ -1,0 +1,11 @@
+# Open Source Contributor — UnvibeCode
+
+**Contributor:** Dhanush M  
+**Credential ID:** UVC26-OSC-005  
+**Issuing organization:** Alphashots.ai  
+**Issue date:** September 2026  
+**Program:** UnvibeCode Engineering Challenge 2026  
+**Status:** Open Source Contributor  
+**Repository:** https://github.com/FinanceFlash/unvibecode
+
+This credential recognizes Dhanush M for an open-source contribution to UnvibeCode during the UnvibeCode Engineering Challenge 2026.

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-005.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-005.md
@@ -4,8 +4,7 @@
 **Credential ID:** UVC26-OSC-005  
 **Issuing organization:** Alphashots.ai  
 **Issue date:** September 2026  
-**Program:** UnvibeCode Engineering Challenge 2026  
 **Status:** Open Source Contributor  
 **Repository:** https://github.com/FinanceFlash/unvibecode
 
-This credential recognizes Dhanush M for an open-source contribution to UnvibeCode during the UnvibeCode Engineering Challenge 2026.
+This credential recognizes **Dhanush M** as an **Open Source Contributor to UnvibeCode**.

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-006.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-006.md
@@ -1,0 +1,11 @@
+# Open Source Contributor — UnvibeCode
+
+**Contributor:** Subhankar Nath  
+**Credential ID:** UVC26-OSC-006  
+**Issuing organization:** Alphashots.ai  
+**Issue date:** September 2026  
+**Program:** UnvibeCode Engineering Challenge 2026  
+**Status:** Open Source Contributor  
+**Repository:** https://github.com/FinanceFlash/unvibecode
+
+This credential recognizes Subhankar Nath for an open-source contribution to UnvibeCode during the UnvibeCode Engineering Challenge 2026.

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-006.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-006.md
@@ -4,8 +4,7 @@
 **Credential ID:** UVC26-OSC-006  
 **Issuing organization:** Alphashots.ai  
 **Issue date:** September 2026  
-**Program:** UnvibeCode Engineering Challenge 2026  
 **Status:** Open Source Contributor  
 **Repository:** https://github.com/FinanceFlash/unvibecode
 
-This credential recognizes Subhankar Nath for an open-source contribution to UnvibeCode during the UnvibeCode Engineering Challenge 2026.
+This credential recognizes **Subhankar Nath** as an **Open Source Contributor to UnvibeCode**.


### PR DESCRIPTION
## Summary

Adds public verification records for six recognized Open Source Contributors to UnvibeCode and four additional Top 10 recipients from the UnvibeCode Engineering Challenge 2026.

## Added

Directory:

`docs/OSS_Contributor_Credentials/`

### Open Source Contributor credentials

- `UVC26-OSC-001.md` — Hariom Hatwate
- `UVC26-OSC-002.md` — Drashan Gowda A.N
- `UVC26-OSC-003.md` — Aditya Sarade
- `UVC26-OSC-004.md` — Shruti Thakur
- `UVC26-OSC-005.md` — Dhanush M
- `UVC26-OSC-006.md` — Subhankar Nath

### Top 10 — UnvibeCode Engineering Challenge 2026

- `UVC26-TOP10-007.md` — Lahari
- `UVC26-TOP10-008.md` — K. Vishal Kumar
- `UVC26-TOP10-009.md` — Muhammad Fahaz Khan
- `UVC26-TOP10-010.md` — Amarnath Sharma

`README.md` documents both credential types and their public verification IDs.

Each record is issued by Alphashots.ai and can be used as a public verification URL for LinkedIn Licenses & Certifications, resumes, or portfolios.