### PR TITLE
Add Top 10 UnvibeCode challenge credentials

### DIFF
--- a/docs/OSS_Contributor_Credentials/README.md
+++ b/docs/OSS_Contributor_Credentials/README.md
@@ -1,17 +1,15 @@
-# UnvibeCode Open Source Contributor Credentials
+# UnvibeCode Contributor and Challenge Credentials
 
-This directory contains public verification records for recognized **Open Source Contributors to UnvibeCode**.
+This directory contains public verification records issued by **Alphashots.ai** for recognized contributors and selected challenge participants.
 
-Each credential is issued by **Alphashots.ai** and may be referenced from LinkedIn under **Licenses & Certifications**, or included on a resume or portfolio as a public verification record.
+These records may be referenced from LinkedIn under **Licenses & Certifications**, or included on a resume or portfolio as public verification records.
 
-## Credential format
+## Open Source Contributor credentials
 
 - **Credential name:** Open Source Contributor — UnvibeCode
 - **Issuing organization:** Alphashots.ai
 - **Issue date:** September 2026
 - **Repository:** https://github.com/FinanceFlash/unvibecode
-
-## Issued credentials
 
 | Credential ID | Contributor |
 | --- | --- |
@@ -21,5 +19,19 @@ Each credential is issued by **Alphashots.ai** and may be referenced from Linked
 | UVC26-OSC-004 | Shruti Thakur |
 | UVC26-OSC-005 | Dhanush M |
 | UVC26-OSC-006 | Subhankar Nath |
+
+## Top 10 — UnvibeCode Engineering Challenge 2026
+
+- **Credential name:** Top 10 — UnvibeCode Engineering Challenge 2026
+- **Issuing organization:** Alphashots.ai
+- **Issue date:** September 2026
+- **Repository:** https://github.com/FinanceFlash/unvibecode
+
+| Credential ID | Recipient |
+| --- | --- |
+| UVC26-TOP10-007 | Lahari |
+| UVC26-TOP10-008 | K. Vishal Kumar |
+| UVC26-TOP10-009 | Muhammad Fahaz Khan |
+| UVC26-TOP10-010 | Amarnath Sharma |
 
 Each credential ID has an individual public verification record in this directory.

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP10-007.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP10-007.md
@@ -1,0 +1,10 @@
+# Top 10 — UnvibeCode Engineering Challenge 2026
+
+**Recipient:** Lahari  
+**Credential ID:** UVC26-TOP10-007  
+**Issuing organization:** Alphashots.ai  
+**Issue date:** September 2026  
+**Recognition:** Top 10  
+**Repository:** https://github.com/FinanceFlash/unvibecode
+
+This credential recognizes Lahari for achieving a **Top 10** position in the **UnvibeCode Engineering Challenge 2026**.

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP10-008.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP10-008.md
@@ -1,0 +1,10 @@
+# Top 10 — UnvibeCode Engineering Challenge 2026
+
+**Recipient:** K. Vishal Kumar  
+**Credential ID:** UVC26-TOP10-008  
+**Issuing organization:** Alphashots.ai  
+**Issue date:** September 2026  
+**Recognition:** Top 10  
+**Repository:** https://github.com/FinanceFlash/unvibecode
+
+This credential recognizes K. Vishal Kumar for achieving a **Top 10** position in the **UnvibeCode Engineering Challenge 2026**.

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP10-009.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP10-009.md
@@ -1,0 +1,10 @@
+# Top 10 — UnvibeCode Engineering Challenge 2026
+
+**Recipient:** Muhammad Fahaz Khan  
+**Credential ID:** UVC26-TOP10-009  
+**Issuing organization:** Alphashots.ai  
+**Issue date:** September 2026  
+**Recognition:** Top 10  
+**Repository:** https://github.com/FinanceFlash/unvibecode
+
+This credential recognizes Muhammad Fahaz Khan for achieving a **Top 10** position in the **UnvibeCode Engineering Challenge 2026**.

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP10-010.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP10-010.md
@@ -1,0 +1,10 @@
+# Top 10 — UnvibeCode Engineering Challenge 2026
+
+**Recipient:** Amarnath Sharma  
+**Credential ID:** UVC26-TOP10-010  
+**Issuing organization:** Alphashots.ai  
+**Issue date:** September 2026  
+**Recognition:** Top 10  
+**Repository:** https://github.com/FinanceFlash/unvibecode
+
+This credential recognizes Amarnath Sharma for achieving a **Top 10** position in the **UnvibeCode Engineering Challenge 2026**.


### PR DESCRIPTION
## Summary

Adds public Top 10 credential records for ranks 7–10 of the UnvibeCode Engineering Challenge 2026 in the existing credential directory.

Directory:

`docs/OSS_Contributor_Credentials/`

## Added

- `UVC26-TOP10-007.md` — Lahari
- `UVC26-TOP10-008.md` — K. Vishal Kumar
- `UVC26-TOP10-009.md` — Muhammad Fahaz Khan
- `UVC26-TOP10-010.md` — Amarnath Sharma

Also updates `README.md` to distinguish the existing Open Source Contributor credentials from the Top 10 challenge credentials.

Each Top 10 record is issued by Alphashots.ai and provides a unique public credential ID suitable for LinkedIn Licenses & Certifications, resumes, and portfolios.