### PR TITLE
Expand Hariom contributor credential

### DIFF
--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-001.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-001.md
@@ -1,10 +1,41 @@
-# Open Source Contributor — UnvibeCode
+# Hariom Hatwate
 
-**Contributor:** Hariom Hatwate  
+## Open Source Contributor — UnvibeCode
+
 **Credential ID:** UVC26-OSC-001  
-**Issuing organization:** Alphashots.ai  
+**Issued by:** Alphashots.ai  
 **Issue date:** September 2026  
-**Status:** Open Source Contributor  
-**Repository:** https://github.com/FinanceFlash/unvibecode
+**Status:** Verified Open Source Contributor  
+**Recognition:** Ranked Top 10 — UnvibeCode Engineering Challenge 2026
 
-This credential recognizes **Hariom Hatwate** as an **Open Source Contributor to UnvibeCode**.
+---
+
+## Contribution
+
+Hariom ranked among the **Top 10 contributors** for the quality of his analysis and evidence-based feedback.
+
+He carefully investigated a business-risk finding instead of accepting the result at face value. He validated what was actually happening and showed that unusual technical behavior should not automatically be classified as a business flaw without evidence of real application impact.
+
+His contribution helped strengthen UnvibeCode's approach to **accurate findings, clearer risk interpretation, and evidence-backed engineering analysis**.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.


### PR DESCRIPTION
Expands Hariom Hatwate's public contributor credential with:

- Top 10 recognition
- A more detailed contribution summary
- A concise UnvibeCode description
- Direct answers for understanding complex codebases and tracing business workflows
- Links back to the main UnvibeCode repository and AI Engineering Cheatsheet

The credential remains inside the main `FinanceFlash/unvibecode` repository so visits stay close to the project and its star action.

No merge performed.