### PR TITLE
Add Top 30 credential pages

### DIFF
--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-011.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-011.md
@@ -1,0 +1,47 @@
+# Akshat Chauhan
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-011  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Akshat Chauhan ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-012.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-012.md
@@ -1,0 +1,47 @@
+# Rohit Sanju Patil
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-012  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Rohit Sanju Patil ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-013.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-013.md
@@ -1,0 +1,47 @@
+# Aarav Maloo
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-013  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Aarav Maloo ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-014.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-014.md
@@ -1,0 +1,47 @@
+# Aditya Raj Verma
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-014  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Aditya Raj Verma ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-015.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-015.md
@@ -1,0 +1,47 @@
+# Pavaneswar Nelagonda
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-015  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Pavaneswar Nelagonda ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-016.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-016.md
@@ -1,0 +1,47 @@
+# Pranshu Garg
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-016  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Pranshu Garg ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-017.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-017.md
@@ -1,0 +1,47 @@
+# Srija Ghosh
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-017  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Srija Ghosh ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-018.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-018.md
@@ -1,0 +1,47 @@
+# Abkari Mohammed Sayeem
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-018  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Abkari Mohammed Sayeem ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-019.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-019.md
@@ -1,0 +1,47 @@
+# Lokesh Saini
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-019  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Lokesh Saini ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-020.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-020.md
@@ -1,0 +1,47 @@
+# Aakriti Jha
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-020  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Aakriti Jha ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-021.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-021.md
@@ -1,0 +1,47 @@
+# Rohith Pariki
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-021  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Rohith Pariki ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-022.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-022.md
@@ -1,0 +1,47 @@
+# Amra
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-022  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Amra ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-023.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-023.md
@@ -1,0 +1,47 @@
+# Juhi Sharma
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-023  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Juhi Sharma ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-024.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-024.md
@@ -1,0 +1,47 @@
+# Ishaan Ahlawat
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-024  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Ishaan Ahlawat ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-025.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-025.md
@@ -1,0 +1,47 @@
+# Aryan Bhargava
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-025  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Aryan Bhargava ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-026.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-026.md
@@ -1,0 +1,47 @@
+# Vijjada Prem Sai
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-026  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Vijjada Prem Sai ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-027.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-027.md
@@ -1,0 +1,47 @@
+# Silky Vyas
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-027  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Silky Vyas ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-028.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-028.md
@@ -1,0 +1,47 @@
+# Aradhya Katiyar
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-028  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Aradhya Katiyar ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-029.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-029.md
@@ -1,0 +1,47 @@
+# Shashwat Kansal
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-029  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Shashwat Kansal ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-030.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-030.md
@@ -1,0 +1,47 @@
+# Mahi Parmar
+
+## Top 30 — UnvibeCode Engineering Challenge 2026
+
+**Credential ID:** UVC26-TOP30-030  
+**Issued by:** Alphashots.ai  
+**Issue date:** September 2026  
+**Status:** Verified Top 30 Recognition  
+**Recognition:** Ranked Top 30 — UnvibeCode Engineering Challenge 2026
+
+---
+
+## Recognition
+
+Mahi Parmar ranked among the **Top 30 participants** in the UnvibeCode Engineering Challenge 2026.
+
+This recognition reflects the quality and relevance of the participant's contribution to reviewing and improving UnvibeCode as an open-source engineering project.
+
+---
+
+### What is UnvibeCode?
+
+UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+#### How do you understand a complex codebase?
+
+Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
+
+#### How do you trace business workflows in a codebase?
+
+UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+
+---
+
+### Explore
+
+[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+
+---
+
+<p align="center">
+  <img src="top-30-unvibecode-challenge-2026.svg"
+       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
+       width="520">
+</p>

--- a/docs/OSS_Contributor_Credentials/top-30-unvibecode-challenge-2026.svg
+++ b/docs/OSS_Contributor_Credentials/top-30-unvibecode-challenge-2026.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="640" viewBox="0 0 1600 640" role="img" aria-labelledby="title desc">
+  <title id="title">Top 30 — UnvibeCode Engineering Challenge 2026</title>
+  <desc id="desc">Congratulations graphic recognizing Top 30 participants in the UnvibeCode Engineering Challenge 2026.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#eef5ff"/>
+    </linearGradient>
+    <linearGradient id="gold" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f8d46b"/>
+      <stop offset="1" stop-color="#c88a00"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="640" fill="url(#bg)"/>
+  <path d="M0 470 C280 360 430 620 760 520 C1080 420 1280 350 1600 430 L1600 640 L0 640 Z" fill="#dbe9ff" opacity="0.65"/>
+  <text x="800" y="105" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="34" letter-spacing="12" fill="#24446d">CONGRATULATIONS</text>
+  <text x="800" y="315" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="150" font-weight="700" fill="#0c2f5d">Top <tspan fill="url(#gold)">30</tspan></text>
+  <text x="800" y="395" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="54" font-weight="700" fill="#0c2f5d">UnvibeCode Engineering Challenge 2026</text>
+  <text x="800" y="465" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="24" letter-spacing="7" fill="#6a86aa">BUILD • LEARN • CREATE • BETTER ENGINEERING</text>
+  <text x="800" y="565" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="24" fill="#24446d">Recognizing thoughtful contributions to open-source engineering</text>
+  <g fill="url(#gold)">
+    <circle cx="310" cy="200" r="8"/><circle cx="1280" cy="180" r="7"/><circle cx="1380" cy="320" r="6"/><circle cx="220" cy="340" r="6"/>
+  </g>
+</svg>


### PR DESCRIPTION
Adds Top 30 credential pages for ranks 11–30, completing the Top 30 credential set alongside the already-merged Top 10 pages.

Each new credential includes:
- unique UVC26-TOP30 credential ID
- verified Top 30 recognition
- concise UnvibeCode context
- links to the main UnvibeCode repository and AI Engineering Cheatsheet
- shared Top 30 challenge recognition graphic

No README changes in this PR. No merge performed.