### PR TITLE
Standardize reverse-engineering positioning across README and credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UnvibeCode
 
-## Understand complex codebases by tracing business workflows, business logic, connected code, edge cases, and evidence-backed risks.
+## Reverse engineer a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 *Unvibe complex code. Trace what the business actually does.*
 
@@ -15,7 +15,7 @@
 
 Reading files one by one does not show the complete business workflow. Pasting a large repository into an LLM can also lose the connections between entry points, state changes, dependencies, edge cases, and business outcomes.
 
-**UnvibeCode reverse-engineers the codebase into connected code, business workflows, business logic, and evidence-backed risks.**
+**UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.**
 
 ## Try UnvibeCode
 
@@ -89,7 +89,7 @@ Developer trials across public and personal repositories repeatedly highlighted 
 
 ## What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ### How do you understand a complex codebase?
 

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-001.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-001.md
@@ -22,7 +22,7 @@ His contribution helped strengthen UnvibeCode's approach to **accurate findings,
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-002.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-002.md
@@ -22,7 +22,7 @@ His contribution helped strengthen UnvibeCode’s approach to **practical risk r
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -43,7 +43,5 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 ---
 
 <p align="center">
-  <img src="top-10-unvibecode-challenge-2026.svg"
-       alt="Top 10 — UnvibeCode Engineering Challenge 2026"
-       width="420">
+  <img src="top-10-unvibecode-challenge-2026.svg" alt="Top 10 — UnvibeCode Engineering Challenge 2026" width="420">
 </p>

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-003.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-003.md
@@ -22,7 +22,7 @@ His contribution helped strengthen UnvibeCode’s approach to **root-cause analy
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-004.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-004.md
@@ -22,7 +22,7 @@ Her contribution helped strengthen UnvibeCode’s approach to **correctness, cla
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-005.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-005.md
@@ -22,7 +22,7 @@ His contribution helped strengthen UnvibeCode’s approach to **clearer interpre
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 

--- a/docs/OSS_Contributor_Credentials/UVC26-OSC-006.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-OSC-006.md
@@ -22,7 +22,7 @@ His contribution helped strengthen UnvibeCode’s approach to **clarity, auditab
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP10-007.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP10-007.md
@@ -22,7 +22,7 @@ Her contribution helped strengthen UnvibeCode’s approach to **context complete
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP10-008.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP10-008.md
@@ -22,7 +22,7 @@ His contribution helped strengthen UnvibeCode’s approach to **better communica
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP10-009.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP10-009.md
@@ -22,7 +22,7 @@ His contribution helped strengthen UnvibeCode’s approach to **better user expe
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP10-010.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP10-010.md
@@ -22,7 +22,7 @@ His contribution helped strengthen UnvibeCode’s approach to **robustness, reli
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-051.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-051.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-052.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-052.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-053.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-053.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-054.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-054.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-055.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-055.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-056.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-056.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-057.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-057.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-058.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-058.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-059.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-059.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-060.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-060.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-061.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-061.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-062.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-062.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-063.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-063.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-064.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-064.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-065.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-065.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-066.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-066.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-067.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-067.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-068.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-068.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-069.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-069.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-070.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-070.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-071.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-071.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-072.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-072.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-073.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-073.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-074.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-074.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-075.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-075.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-076.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-076.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-077.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-077.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-078.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-078.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-079.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-079.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-080.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-080.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-081.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-081.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-082.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-082.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-083.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-083.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-084.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-084.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-085.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-085.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-086.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-086.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-087.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-087.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-088.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-088.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-089.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-089.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-090.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-090.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-091.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-091.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-092.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-092.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-093.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-093.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-094.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-094.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-095.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-095.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-096.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-096.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-097.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-097.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-098.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-098.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-099.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-099.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP100-100.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP100-100.md
@@ -20,21 +20,13 @@ This recognition reflects the participant's contribution to reviewing, testing, 
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-011.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-011.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-012.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-012.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-013.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-013.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-014.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-014.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-015.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-015.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-016.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-016.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-017.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-017.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-018.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-018.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-019.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-019.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-020.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-020.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-021.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-021.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-022.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-022.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-023.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-023.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-024.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-024.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-025.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-025.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-026.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-026.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-027.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-027.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-028.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-028.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-029.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-029.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP30-030.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP30-030.md
@@ -20,7 +20,7 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 #### How do you understand a complex codebase?
 
@@ -34,14 +34,10 @@ UnvibeCode traces **business workflows and business logic** across the codebase 
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode) — trace business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
-[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet) — practical guides for AI Agents, LLMs, RAG, reliability, observability, production failures, and AI deployment.
+[**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 
 ---
 
-<p align="center">
-  <img src="top-30-unvibecode-challenge-2026.svg"
-       alt="Top 30 — UnvibeCode Engineering Challenge 2026"
-       width="520">
-</p>
+<p align="center"><img src="top-30-unvibecode-challenge-2026.svg" alt="Top 30 — UnvibeCode Engineering Challenge 2026" width="520"></p>

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-031.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-031.md
@@ -20,11 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
+
+---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-032.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-032.md
@@ -20,11 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
+
+---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-033.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-033.md
@@ -20,11 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
+
+---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-034.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-034.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-035.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-035.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-036.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-036.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-037.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-037.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-038.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-038.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-039.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-039.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-040.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-040.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-041.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-041.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-042.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-042.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-043.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-043.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-044.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-044.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-045.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-045.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-046.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-046.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-047.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-047.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-048.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-048.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-049.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-049.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 

--- a/docs/OSS_Contributor_Credentials/UVC26-TOP50-050.md
+++ b/docs/OSS_Contributor_Credentials/UVC26-TOP50-050.md
@@ -20,21 +20,13 @@ This recognition reflects the quality and relevance of the participant's contrib
 
 ### What is UnvibeCode?
 
-UnvibeCode is an open-source codebase analysis tool that helps developers **understand complex codebases** by tracing business workflows, business logic, connected code, entry points, edge cases, and evidence-backed risks.
-
-#### How do you understand a complex codebase?
-
-Start with **business workflows, not individual files**. UnvibeCode traces each workflow to the connected code, entry points, dependencies, and edge cases.
-
-#### How do you trace business workflows in a codebase?
-
-UnvibeCode traces **business workflows and business logic** across the codebase and connects them to the relevant files, functions, dependencies, and supporting code evidence.
+UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.
 
 ---
 
 ### Explore
 
-[**Understand a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
+[**Reverse engineer a complex codebase with UnvibeCode**](https://github.com/FinanceFlash/unvibecode)
 
 [**AI Engineering Cheatsheet**](https://github.com/FinanceFlash/unvibecode/tree/main/AI%20Engineering%20Cheatsheet)
 


### PR DESCRIPTION
Standardizes UnvibeCode's product positioning around one canonical sentence:

> UnvibeCode reverse-engineers a complex codebase into business workflows, connected code, edge cases, and evidence-backed risks.

Changes:
- updates the README hero and `What is UnvibeCode?` answer to the canonical reverse-engineering positioning
- applies the same `What is UnvibeCode?` wording across all 100 public credential pages
- preserves every existing credential ID and stable credential path
- keeps each Top 10 contributor's individual contribution text intact
- updates credential CTA wording toward reverse-engineering a complex codebase

GitHub repository Topics are not changed in this PR because Topics are repository metadata rather than repository files.

No merge performed.